### PR TITLE
fix(landing): server-render docs package command code blocks

### DIFF
--- a/landing/src/components/docs/package-command.tsx
+++ b/landing/src/components/docs/package-command.tsx
@@ -1,4 +1,5 @@
-import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { highlight } from "fumadocs-core/highlight";
+import { CodeBlock, Pre } from "fumadocs-ui/components/codeblock";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 import { shikiThemes } from "@/lib/shiki-themes";
@@ -16,32 +17,38 @@ function runCommand(command: string, manager: string) {
   return `npx ${command}`;
 }
 
-export function PackageInstall({ package: pkg }: { package: string }) {
+async function HighlightedCode({ code }: { code: string }) {
+  return highlight(code, {
+    lang: "bash",
+    themes: shikiThemes,
+    components: {
+      pre: (props) => (
+        <CodeBlock {...props}>
+          <Pre>{props.children}</Pre>
+        </CodeBlock>
+      ),
+    },
+  });
+}
+
+export async function PackageInstall({ package: pkg }: { package: string }) {
   return (
     <Tabs items={[...managers]}>
       {managers.map((m) => (
         <Tab key={m} value={m}>
-          <DynamicCodeBlock
-            lang="bash"
-            code={installCommand(pkg, m)}
-            options={{ themes: shikiThemes }}
-          />
+          <HighlightedCode code={installCommand(pkg, m)} />
         </Tab>
       ))}
     </Tabs>
   );
 }
 
-export function PackageRun({ command }: { command: string }) {
+export async function PackageRun({ command }: { command: string }) {
   return (
     <Tabs items={[...managers]}>
       {managers.map((m) => (
         <Tab key={m} value={m}>
-          <DynamicCodeBlock
-            lang="bash"
-            code={runCommand(command, m)}
-            options={{ themes: shikiThemes }}
-          />
+          <HighlightedCode code={runCommand(command, m)} />
         </Tab>
       ))}
     </Tabs>


### PR DESCRIPTION
## Summary
- Replace client-side `DynamicCodeBlock` with server-side `highlight` from `fumadocs-core` + `CodeBlock`/`Pre` from `fumadocs-ui`
- Fixes lag on docs page load caused by client-side Shiki highlighting
- Uses the same theme as built-in docs code blocks via shared `shikiThemes`

## Test plan
- [ ] Verify PackageInstall and PackageRun render without flash/lag on docs pages
- [ ] Verify code block styling matches other docs code blocks