### PR TITLE
docs(landing): add skills page under Guides

### DIFF
--- a/landing/content/docs/guides/meta.json
+++ b/landing/content/docs/guides/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Guides",
+  "pages": ["skills"]
+}

--- a/landing/content/docs/guides/skills.mdx
+++ b/landing/content/docs/guides/skills.mdx
@@ -1,0 +1,27 @@
+---
+title: Skills
+description: Agent skills for coding assistants to set up and configure billing with PayKit.
+---
+
+[Agent skills](https://agentskills.io) are portable instruction files (for example `SKILL.md`) that teach your coding agent project conventions, safe patterns, and where to look in the docs. The **PayKit** skill pack lives in the [`getpaykit/skills`](https://github.com/getpaykit/skills) repository.
+
+Install with the [`skills` CLI](https://www.npmjs.com/package/skills) (uses `npx` so nothing global is required):
+
+```bash title="terminal"
+npx skills add getpaykit/skills
+```
+
+Your editor or agent loads skills from its configured skills directory (often project-level). After installing, restart the agent or reload skills if your tool requires it.
+
+## Available Skills
+
+- **create-paykit** Scaffold billing in a new project. Detects your framework, configures the database, sets up Stripe, mounts the route handler, and creates the client.
+- **paykit-best-practices** General configuration reference for `createPayKit` options, customer identification, event handlers, and testing mode.
+- **plans-and-features** Schema DSL covering `feature()`, `plan()`, plan groups, boolean and metered features, and type inference.
+- **subscriptions** The `subscribe()` API and its transition semantics: upgrades, downgrades, cancellations, and checkout flows.
+- **metered-usage** Entitlement gating with `check()` and `report()`, usage tracking, and balance resets.
+- **stripe** Stripe provider setup, webhook configuration, `customerPortal()`, and syncing plans with `push`.
+
+## Supported Agents
+
+Skills work with any agent that supports the [Agent Skills](https://agentskills.io) specification, including Claude Code, Cursor, Windsurf, Copilot, and others.

--- a/landing/content/docs/meta.json
+++ b/landing/content/docs/meta.json
@@ -10,6 +10,8 @@
     "---Providers---",
     "providers",
     "---Plugins---",
-    "plugins"
+    "plugins",
+    "---Guides---",
+    "guides"
   ]
 }

--- a/landing/src/components/docs/docs-icons.tsx
+++ b/landing/src/components/docs/docs-icons.tsx
@@ -2,6 +2,7 @@ import {
   Blocks,
   BookMarked,
   BookOpen,
+  Bot,
   ChevronDown,
   Code2,
   Coins,
@@ -77,6 +78,7 @@ const pageIcons = {
   "subscription billing": <Repeat className="docs-category-icon size-3! shrink-0" />,
   "metered usage": <Gauge className="docs-category-icon size-3! shrink-0" />,
   dashboard: <LayoutDashboard className="docs-category-icon size-3! shrink-0" />,
+  skills: <Bot className="docs-category-icon size-3! shrink-0" />,
 } as const;
 
 const enabledProviders = new Set(["stripe"]);


### PR DESCRIPTION
## Summary
- Add new **Guides** docs category with a **Skills** page
- Skills page documents the `getpaykit/skills` agent skill pack (install, available skills, supported agents)
- Register `Bot` icon for the skills page and wire up the Guides category in the sidebar

## Test plan
- [ ] Verify the docs sidebar shows Guides > Skills
- [ ] Verify the skills page renders correctly at `/docs/guides/skills`