### PR TITLE
fix(landing): use Blocks icon for plugins consistently

### DIFF
--- a/landing/src/components/docs/docs-icons.tsx
+++ b/landing/src/components/docs/docs-icons.tsx
@@ -14,7 +14,6 @@ import {
   LayoutDashboard,
   Layers,
   Monitor,
-  Plug,
   ReceiptText,
   Repeat,
   Route,
@@ -39,7 +38,7 @@ const categoryIcons = {
   providers: <CreditCard className="docs-category-icon size-3.5! shrink-0" />,
   databases: <Database className="docs-category-icon size-3.5! shrink-0" />,
   integrations: <Blocks className="docs-category-icon size-3.5! shrink-0" />,
-  plugins: <Plug className="docs-category-icon size-3.5! shrink-0" />,
+  plugins: <Blocks className="docs-category-icon size-3.5! shrink-0" />,
   guides: <BookMarked className="docs-category-icon size-3.5! shrink-0" />,
 } as const;
 
@@ -65,13 +64,13 @@ const pageIcons = {
   "prisma adapter": <Database className="docs-category-icon size-3! shrink-0" />,
   nextjs: <Server className="docs-category-icon size-3! shrink-0" />,
   "next js": <Server className="docs-category-icon size-3! shrink-0" />,
-  "custom backend": <Plug className="docs-category-icon size-3! shrink-0" />,
+
   "create a payment provider": <CreditCard className="docs-category-icon size-3! shrink-0" />,
   "plans & features": <Layers className="docs-category-icon size-3! shrink-0" />,
   customers: <Users className="docs-category-icon size-3! shrink-0" />,
   subscriptions: <Repeat className="docs-category-icon size-3! shrink-0" />,
   entitlements: <Shield className="docs-category-icon size-3! shrink-0" />,
-  plugins: <Plug className="docs-category-icon size-3! shrink-0" />,
+  plugins: <Blocks className="docs-category-icon size-3! shrink-0" />,
   client: <Monitor className="docs-category-icon size-3! shrink-0" />,
   cli: <Terminal className="docs-category-icon size-3! shrink-0" />,
   "subscription billing": <Repeat className="docs-category-icon size-3! shrink-0" />,


### PR DESCRIPTION
## Summary
- Changed plugins category and page icons from `Plug` to `Blocks` in docs sidebar to match the features sections
- Removed unused "custom backend" icon entry
- Removed unused `Plug` import