### PR TITLE
feat(paykit): add Express and Fastify route handlers [PAY-184]

### DIFF
--- a/landing/content/docs/get-started/installation.mdx
+++ b/landing/content/docs/get-started/installation.mdx
@@ -95,13 +95,33 @@ To handle webhooks and client API requests, you need to set up a request handler
 
 Create a new file or route in your framework's designated catch-all route handler. This route should handle requests for the path /paykit/* (unless you've configured a different base path).
 
-<Tabs items={["Next.js", "Other"]}>
+<Tabs items={["Next.js", "Express", "Fastify", "Other"]}>
   <Tab value="Next.js">
     ```ts title="src/app/paykit/[[...slug]]/route.ts"
     import { paykitHandler } from "paykitjs/handlers/next";
     import { paykit } from "@/lib/paykit";
 
     export const { GET, POST } = paykitHandler(paykit);
+    ```
+  </Tab>
+  <Tab value="Express">
+    ```ts title="server.ts"
+    import express from "express";
+    import { paykitHandler } from "paykitjs/handlers/express";
+    import { paykit } from "./paykit";
+
+    const app = express();
+    app.all("/paykit/*", paykitHandler(paykit));
+    ```
+  </Tab>
+  <Tab value="Fastify">
+    ```ts title="server.ts"
+    import Fastify from "fastify";
+    import { paykitHandler } from "paykitjs/handlers/fastify";
+    import { paykit } from "./paykit";
+
+    const app = Fastify();
+    app.all("/paykit/*", paykitHandler(paykit));
     ```
   </Tab>
   <Tab value="Other">

--- a/packages/paykit/package.json
+++ b/packages/paykit/package.json
@@ -30,6 +30,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./handlers/next": "./src/handlers/next.ts",
+    "./handlers/express": "./src/handlers/express.ts",
+    "./handlers/fastify": "./src/handlers/fastify.ts",
     "./client": "./src/client/index.ts"
   },
   "publishConfig": {
@@ -41,6 +43,14 @@
       "./handlers/next": {
         "types": "./dist/handlers/next.d.ts",
         "default": "./dist/handlers/next.js"
+      },
+      "./handlers/express": {
+        "types": "./dist/handlers/express.d.ts",
+        "default": "./dist/handlers/express.js"
+      },
+      "./handlers/fastify": {
+        "types": "./dist/handlers/fastify.d.ts",
+        "default": "./dist/handlers/fastify.js"
       },
       "./client": {
         "types": "./dist/client/index.d.ts",

--- a/packages/paykit/src/handlers/__tests__/express.test.ts
+++ b/packages/paykit/src/handlers/__tests__/express.test.ts
@@ -1,0 +1,103 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { paykitHandler } from "../express";
+
+function createMockPayKit(
+  handler: (request: Request) => Promise<Response>,
+): Pick<{ handler: (request: Request) => Promise<Response> }, "handler"> {
+  return { handler };
+}
+
+describe("express handler", () => {
+  const paykit = createMockPayKit(async (request) => {
+    const url = new URL(request.url);
+    if (url.pathname === "/paykit/api/health") {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (url.pathname === "/paykit/api/echo" && request.method === "POST") {
+      const body = await request.json();
+      return new Response(JSON.stringify({ echo: body }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    return new Response("Not Found", { status: 404 });
+  });
+
+  const handler = paykitHandler(paykit);
+  let baseUrl: string;
+  const server = createServer(handler);
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => resolve());
+    });
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://localhost:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it("handles GET requests", async () => {
+    const res = await fetch(`${baseUrl}/paykit/api/health`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("handles POST requests with JSON body", async () => {
+    const res = await fetch(`${baseUrl}/paykit/api/echo`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "hello" }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.echo).toEqual({ message: "hello" });
+  });
+
+  it("forwards response status codes", async () => {
+    const res = await fetch(`${baseUrl}/unknown`);
+    expect(res.status).toBe(404);
+  });
+
+  it("forwards response headers", async () => {
+    const res = await fetch(`${baseUrl}/paykit/api/health`);
+    expect(res.headers.get("content-type")).toBe("application/json");
+  });
+
+  it("forwards request headers to paykit.handler", async () => {
+    const pk = createMockPayKit(async (request) => {
+      const auth = request.headers.get("authorization");
+      return new Response(JSON.stringify({ auth }), { status: 200 });
+    });
+    const h = paykitHandler(pk);
+    const s = createServer(h);
+
+    await new Promise<void>((resolve) => s.listen(0, () => resolve()));
+    const addr = s.address() as AddressInfo;
+
+    try {
+      const res = await fetch(`http://localhost:${addr.port}/test`, {
+        headers: { authorization: "Bearer token123" },
+      });
+      const data = await res.json();
+      expect(data.auth).toBe("Bearer token123");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        s.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  });
+});

--- a/packages/paykit/src/handlers/__tests__/fastify.test.ts
+++ b/packages/paykit/src/handlers/__tests__/fastify.test.ts
@@ -1,0 +1,157 @@
+import { createServer } from "node:http";
+import type { IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { paykitHandler } from "../fastify";
+
+function createMockPayKit(
+  handler: (request: Request) => Promise<Response>,
+): Pick<{ handler: (request: Request) => Promise<Response> }, "handler"> {
+  return { handler };
+}
+
+function createFakeFastifyServer(
+  handlerFn: (
+    request: {
+      method: string;
+      url: string;
+      headers: Record<string, string | string[] | undefined>;
+      raw: IncomingMessage;
+    },
+    reply: {
+      status: (code: number) => unknown;
+      headers: (headers: Record<string, string>) => unknown;
+      send: (payload: unknown) => unknown;
+    },
+  ) => Promise<void>,
+) {
+  return createServer(async (req, res) => {
+    const fastifyRequest = {
+      method: req.method ?? "GET",
+      url: req.url ?? "/",
+      headers: req.headers as Record<string, string | string[] | undefined>,
+      raw: req,
+    };
+
+    let statusCode = 200;
+    let responseHeaders: Record<string, string> = {};
+
+    const fastifyReply = {
+      status(code: number) {
+        statusCode = code;
+        return fastifyReply;
+      },
+      headers(h: Record<string, string>) {
+        responseHeaders = h;
+        return fastifyReply;
+      },
+      send(payload: unknown) {
+        for (const [key, value] of Object.entries(responseHeaders)) {
+          res.setHeader(key, value);
+        }
+        res.writeHead(statusCode);
+        if (payload instanceof Uint8Array || Buffer.isBuffer(payload)) {
+          res.end(payload);
+        } else {
+          res.end(String(payload));
+        }
+        return fastifyReply;
+      },
+    };
+
+    await handlerFn(fastifyRequest, fastifyReply);
+  });
+}
+
+describe("fastify handler", () => {
+  const paykit = createMockPayKit(async (request) => {
+    const url = new URL(request.url);
+    if (url.pathname === "/paykit/api/health") {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (url.pathname === "/paykit/api/echo" && request.method === "POST") {
+      const body = await request.json();
+      return new Response(JSON.stringify({ echo: body }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    return new Response("Not Found", { status: 404 });
+  });
+
+  const handler = paykitHandler(paykit);
+  let baseUrl: string;
+  const server = createFakeFastifyServer(handler);
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => resolve());
+    });
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://localhost:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it("handles GET requests", async () => {
+    const res = await fetch(`${baseUrl}/paykit/api/health`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("handles POST requests with JSON body", async () => {
+    const res = await fetch(`${baseUrl}/paykit/api/echo`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "hello" }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.echo).toEqual({ message: "hello" });
+  });
+
+  it("forwards response status codes", async () => {
+    const res = await fetch(`${baseUrl}/unknown`);
+    expect(res.status).toBe(404);
+  });
+
+  it("forwards response headers", async () => {
+    const res = await fetch(`${baseUrl}/paykit/api/health`);
+    expect(res.headers.get("content-type")).toBe("application/json");
+  });
+
+  it("forwards request headers to paykit.handler", async () => {
+    const pk = createMockPayKit(async (request) => {
+      const auth = request.headers.get("authorization");
+      return new Response(JSON.stringify({ auth }), { status: 200 });
+    });
+    const h = paykitHandler(pk);
+    const s = createFakeFastifyServer(h);
+
+    await new Promise<void>((resolve) => s.listen(0, () => resolve()));
+    const addr = s.address() as AddressInfo;
+
+    try {
+      const res = await fetch(`http://localhost:${addr.port}/test`, {
+        headers: { authorization: "Bearer token123" },
+      });
+      const data = await res.json();
+      expect(data.auth).toBe("Bearer token123");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        s.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  });
+});

--- a/packages/paykit/src/handlers/express.ts
+++ b/packages/paykit/src/handlers/express.ts
@@ -1,0 +1,63 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import type { PayKitInstance } from "../types/instance";
+
+function toWebRequest(req: IncomingMessage): Request {
+  const proto = req.headers["x-forwarded-proto"] ?? "http";
+  const host = req.headers.host ?? "localhost";
+  const url = new URL(req.url ?? "/", `${proto}://${host}`);
+
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        headers.append(key, v);
+      }
+    } else {
+      headers.set(key, value);
+    }
+  }
+
+  const method = req.method ?? "GET";
+  const hasBody = method !== "GET" && method !== "HEAD";
+
+  return new Request(url, {
+    method,
+    headers,
+    body: hasBody ? (req as unknown as ReadableStream) : null,
+    // @ts-expect-error -- Node 22+ supports duplex on Request init
+    duplex: hasBody ? "half" : undefined,
+  });
+}
+
+async function writeWebResponse(webResponse: Response, res: ServerResponse): Promise<void> {
+  res.writeHead(webResponse.status, Object.fromEntries(webResponse.headers));
+
+  if (!webResponse.body) {
+    res.end();
+    return;
+  }
+
+  const reader = webResponse.body.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      res.write(value);
+    }
+  } finally {
+    reader.releaseLock();
+    res.end();
+  }
+}
+
+export function paykitHandler(
+  paykit: Pick<PayKitInstance, "handler">,
+): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
+  return async (req, res) => {
+    const webRequest = toWebRequest(req);
+    const webResponse = await paykit.handler(webRequest);
+    await writeWebResponse(webResponse, res);
+  };
+}

--- a/packages/paykit/src/handlers/fastify.ts
+++ b/packages/paykit/src/handlers/fastify.ts
@@ -1,0 +1,72 @@
+import type { IncomingMessage } from "node:http";
+
+import type { PayKitInstance } from "../types/instance";
+
+interface FastifyRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string | string[] | undefined>;
+  raw: IncomingMessage;
+}
+
+interface FastifyReply {
+  status: (code: number) => FastifyReply;
+  headers: (headers: Record<string, string>) => FastifyReply;
+  send: (payload: unknown) => FastifyReply;
+}
+
+function toWebRequest(request: FastifyRequest): Request {
+  const proto = request.headers["x-forwarded-proto"] ?? "http";
+  const host = request.headers.host ?? "localhost";
+  const url = new URL(request.url, `${proto}://${host}`);
+
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        headers.append(key, v);
+      }
+    } else {
+      headers.set(key, value);
+    }
+  }
+
+  const method = request.method;
+  const hasBody = method !== "GET" && method !== "HEAD";
+
+  return new Request(url, {
+    method,
+    headers,
+    body: hasBody ? (request.raw as unknown as ReadableStream) : null,
+    // @ts-expect-error -- Node 22+ supports duplex on Request init
+    duplex: hasBody ? "half" : undefined,
+  });
+}
+
+async function writeWebResponse(webResponse: Response, reply: FastifyReply): Promise<void> {
+  const responseHeaders: Record<string, string> = {};
+  webResponse.headers.forEach((value, key) => {
+    responseHeaders[key] = value;
+  });
+
+  reply.status(webResponse.status).headers(responseHeaders);
+
+  if (!webResponse.body) {
+    reply.send("");
+    return;
+  }
+
+  const body = new Uint8Array(await webResponse.arrayBuffer());
+  reply.send(Buffer.from(body));
+}
+
+export function paykitHandler(
+  paykit: Pick<PayKitInstance, "handler">,
+): (request: FastifyRequest, reply: FastifyReply) => Promise<void> {
+  return async (request, reply) => {
+    const webRequest = toWebRequest(request);
+    const webResponse = await paykit.handler(webRequest);
+    await writeWebResponse(webResponse, reply);
+  };
+}

--- a/packages/paykit/tsdown.config.ts
+++ b/packages/paykit/tsdown.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
     index: "src/index.ts",
     "cli/index": "src/cli/index.ts",
     "handlers/next": "src/handlers/next.ts",
+    "handlers/express": "src/handlers/express.ts",
+    "handlers/fastify": "src/handlers/fastify.ts",
     "client/index": "src/client/index.ts",
   },
   fixedExtension: false,


### PR DESCRIPTION
## Summary

- Add `paykitjs/handlers/express` — converts Node.js `IncomingMessage`/`ServerResponse` to Web API `Request`/`Response`
- Add `paykitjs/handlers/fastify` — converts Fastify `request`/`reply` to Web API `Request`/`Response`
- Both use lightweight local interfaces with no runtime dependency on either framework

Closes #100

## Test plan

- [x] Unit tests for Express handler (GET, POST with body, status codes, header forwarding)
- [x] Unit tests for Fastify handler (GET, POST with body, status codes, header forwarding)
- [x] Build passes with new entry points (`pnpm build`)
- [x] Lint passes (`oxlint --deny-warnings`)
- [ ] Changeset to be added after review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Express and Fastify framework integrations for mounting PayKit request handlers, enabling seamless setup with these popular Node.js frameworks.

* **Documentation**
  * Updated installation guide with dedicated configuration examples for Express and Fastify alongside existing Next.js integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->