### PR TITLE
fix(landing): show copied state immediately on copy button

### DIFF
--- a/landing/src/components/ui/use-copy-button.tsx
+++ b/landing/src/components/ui/use-copy-button.tsx
@@ -10,14 +10,12 @@ export function useCopyButton(
 
   const onClick: MouseEventHandler = useEffectEvent(() => {
     if (timeoutRef.current) window.clearTimeout(timeoutRef.current);
-    const res = Promise.resolve(onCopy());
+    void Promise.resolve(onCopy());
 
-    void res.then(() => {
-      setChecked(true);
-      timeoutRef.current = window.setTimeout(() => {
-        setChecked(false);
-      }, 1500);
-    });
+    setChecked(true);
+    timeoutRef.current = window.setTimeout(() => {
+      setChecked(false);
+    }, 1500);
   });
 
   // Avoid updates after being unmounted


### PR DESCRIPTION
## Summary
- Show "copied" state optimistically on code block copy buttons instead of waiting for clipboard API to resolve
- Eliminates ~200-300ms perceived UI delay where nothing happens after clicking copy

## Test plan
- [ ] Click copy button on any docs code block, verify "copied" icon appears instantly