### PR TITLE
perf(paykit): optimize reportEntitlement to single CTE query

### DIFF
--- a/packages/paykit/src/entitlement/__tests__/entitlement.service.test.ts
+++ b/packages/paykit/src/entitlement/__tests__/entitlement.service.test.ts
@@ -2,15 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { reportEntitlement } from "../entitlement.service";
 
-const createUpdateResult = (balance: number) => [{ balance }];
-
-const createUpdateChain = (result: unknown) => ({
-  set: vi.fn().mockReturnValue({
-    where: vi.fn().mockReturnValue({
-      returning: vi.fn().mockResolvedValue(result),
-    }),
-  }),
-});
+const mockExecute = (rows: unknown[]) => vi.fn().mockResolvedValue({ rows });
 
 const createSelectChain = (result: unknown) => ({
   from: vi.fn().mockReturnValue({
@@ -22,110 +14,129 @@ const createSelectChain = (result: unknown) => ({
   }),
 });
 
-const createEntitlementRows = () => [
-  {
-    balance: 3,
-    id: "ent_1",
-    nextResetAt: new Date("2024-02-01T00:00:00.000Z"),
-    originalLimit: 3,
-    resetInterval: "month",
-  },
-  {
-    balance: 4,
-    id: "ent_2",
-    nextResetAt: new Date("2024-02-01T00:00:00.000Z"),
-    originalLimit: 4,
-    resetInterval: "month",
-  },
-];
-
 describe("entitlement/service", () => {
-  it("consumes usage across stacked entitlement rows", async () => {
-    const txUpdate = vi
-      .fn()
-      .mockReturnValueOnce(createUpdateChain(createUpdateResult(0)))
-      .mockReturnValueOnce(createUpdateChain(createUpdateResult(2)));
-
+  it("deducts in a single CTE query when one row has enough balance", async () => {
     const database = {
-      select: vi.fn().mockImplementation(() => createSelectChain(createEntitlementRows())),
-      transaction: vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
-        await fn({ update: txUpdate });
-      }),
+      execute: mockExecute([
+        {
+          hasUnlimited: false,
+          totalBalance: 500,
+          totalLimit: 500,
+          rowCount: 1,
+          earliestResetAt: new Date("2024-02-01"),
+          deductedId: "ent_1",
+          newBalance: 490,
+        },
+      ]),
     } as never;
 
     const result = await reportEntitlement(database, {
-      amount: 5,
+      amount: 10,
       customerId: "customer_123",
-      featureId: "feature_api_calls",
+      featureId: "messages",
       now: new Date("2024-01-15T00:00:00.000Z"),
     });
 
-    expect(txUpdate).toHaveBeenCalledTimes(2);
-    expect(result).toEqual({
-      balance: {
-        limit: 7,
-        remaining: 2,
-        resetAt: new Date("2024-02-01T00:00:00.000Z"),
-        unlimited: false,
-      },
-      success: true,
-    });
-  });
-
-  it("retries on concurrent conflict without double-deducting", async () => {
-    let attempt = 0;
-
-    const database = {
-      select: vi.fn().mockImplementation(() => createSelectChain(createEntitlementRows())),
-      transaction: vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
-        attempt++;
-        if (attempt === 1) {
-          // First attempt: row 1 succeeds, row 2 conflicts → tx rolls back
-          const txUpdate = vi
-            .fn()
-            .mockReturnValueOnce(createUpdateChain(createUpdateResult(0)))
-            .mockReturnValueOnce(createUpdateChain([]));
-          await fn({ update: txUpdate });
-        } else {
-          // Retry: both rows succeed
-          const txUpdate = vi
-            .fn()
-            .mockReturnValueOnce(createUpdateChain(createUpdateResult(0)))
-            .mockReturnValueOnce(createUpdateChain(createUpdateResult(2)));
-          await fn({ update: txUpdate });
-        }
-      }),
-    } as never;
-
-    const result = await reportEntitlement(database, {
-      amount: 5,
-      customerId: "customer_123",
-      featureId: "feature_api_calls",
-      now: new Date("2024-01-15T00:00:00.000Z"),
-    });
-
-    expect(attempt).toBe(2);
     expect(result.success).toBe(true);
+    expect(result.balance!.remaining).toBe(490);
+    expect(result.balance!.limit).toBe(500);
   });
 
-  it("fails gracefully after all retries are exhausted", async () => {
+  it("returns success for unlimited features without deducting", async () => {
     const database = {
-      select: vi.fn().mockImplementation(() => createSelectChain(createEntitlementRows())),
-      // Every attempt conflicts on the first row
-      transaction: vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
-        const txUpdate = vi.fn().mockReturnValueOnce(createUpdateChain([]));
-        await fn({ update: txUpdate });
+      execute: mockExecute([
+        {
+          hasUnlimited: true,
+          totalBalance: 0,
+          totalLimit: 0,
+          rowCount: 1,
+          earliestResetAt: null,
+          deductedId: null,
+          newBalance: null,
+        },
+      ]),
+    } as never;
+
+    const result = await reportEntitlement(database, {
+      amount: 10,
+      customerId: "customer_123",
+      featureId: "messages",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.balance!.unlimited).toBe(true);
+  });
+
+  it("fails in a single query when balance is insufficient", async () => {
+    const database = {
+      execute: mockExecute([
+        {
+          hasUnlimited: false,
+          totalBalance: 5,
+          totalLimit: 500,
+          rowCount: 1,
+          earliestResetAt: new Date("2024-02-01"),
+          deductedId: null,
+          newBalance: null,
+        },
+      ]),
+    } as never;
+
+    const result = await reportEntitlement(database, {
+      amount: 10,
+      customerId: "customer_123",
+      featureId: "messages",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.balance!.remaining).toBe(5);
+  });
+
+  it("falls back to stacked deduction when total suffices but no single row does", async () => {
+    // CTE returns: enough total, but no deductedId (no single row covers it)
+    const rows = [
+      {
+        balance: 3,
+        id: "ent_1",
+        nextResetAt: new Date("2024-02-01"),
+        originalLimit: 3,
+        resetInterval: "month",
+      },
+      {
+        balance: 4,
+        id: "ent_2",
+        nextResetAt: new Date("2024-02-01"),
+        originalLimit: 4,
+        resetInterval: "month",
+      },
+    ];
+
+    const database = {
+      execute: mockExecute([
+        {
+          hasUnlimited: false,
+          totalBalance: 7,
+          totalLimit: 7,
+          rowCount: 2,
+          earliestResetAt: new Date("2024-02-01"),
+          deductedId: null,
+          newBalance: null,
+        },
+      ]),
+      select: vi.fn().mockImplementation(() => createSelectChain(rows.map((r) => ({ ...r })))),
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
       }),
     } as never;
 
     const result = await reportEntitlement(database, {
       amount: 5,
       customerId: "customer_123",
-      featureId: "feature_api_calls",
+      featureId: "messages",
       now: new Date("2024-01-15T00:00:00.000Z"),
     });
 
-    expect(database.transaction).toHaveBeenCalledTimes(3);
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    expect(result.balance!.remaining).toBe(2);
   });
 });

--- a/packages/paykit/src/entitlement/__tests__/entitlement.service.test.ts
+++ b/packages/paykit/src/entitlement/__tests__/entitlement.service.test.ts
@@ -4,31 +4,21 @@ import { reportEntitlement } from "../entitlement.service";
 
 const mockExecute = (rows: unknown[]) => vi.fn().mockResolvedValue({ rows });
 
-const createSelectChain = (result: unknown) => ({
-  from: vi.fn().mockReturnValue({
-    innerJoin: vi.fn().mockReturnValue({
-      innerJoin: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(result),
-      }),
-    }),
-  }),
-});
-
 describe("entitlement/service", () => {
   it("deducts in a single CTE query when one row has enough balance", async () => {
-    const database = {
-      execute: mockExecute([
-        {
-          hasUnlimited: false,
-          totalBalance: 500,
-          totalLimit: 500,
-          rowCount: 1,
-          earliestResetAt: new Date("2024-02-01"),
-          deductedId: "ent_1",
-          newBalance: 490,
-        },
-      ]),
-    } as never;
+    const execute = mockExecute([
+      {
+        hasUnlimited: false,
+        totalBalance: 500,
+        totalLimit: 500,
+        rowCount: 1,
+        earliestResetAt: new Date("2024-02-01"),
+        deductedId: "ent_1",
+        newBalance: 490,
+      },
+    ]);
+    const transaction = vi.fn();
+    const database = { execute, transaction } as never;
 
     const result = await reportEntitlement(database, {
       amount: 10,
@@ -40,22 +30,24 @@ describe("entitlement/service", () => {
     expect(result.success).toBe(true);
     expect(result.balance!.remaining).toBe(490);
     expect(result.balance!.limit).toBe(500);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(transaction).not.toHaveBeenCalled();
   });
 
   it("returns success for unlimited features without deducting", async () => {
-    const database = {
-      execute: mockExecute([
-        {
-          hasUnlimited: true,
-          totalBalance: 0,
-          totalLimit: 0,
-          rowCount: 1,
-          earliestResetAt: null,
-          deductedId: null,
-          newBalance: null,
-        },
-      ]),
-    } as never;
+    const execute = mockExecute([
+      {
+        hasUnlimited: true,
+        totalBalance: 0,
+        totalLimit: 0,
+        rowCount: 1,
+        earliestResetAt: null,
+        deductedId: null,
+        newBalance: null,
+      },
+    ]);
+    const transaction = vi.fn();
+    const database = { execute, transaction } as never;
 
     const result = await reportEntitlement(database, {
       amount: 10,
@@ -65,22 +57,24 @@ describe("entitlement/service", () => {
 
     expect(result.success).toBe(true);
     expect(result.balance!.unlimited).toBe(true);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(transaction).not.toHaveBeenCalled();
   });
 
   it("fails in a single query when balance is insufficient", async () => {
-    const database = {
-      execute: mockExecute([
-        {
-          hasUnlimited: false,
-          totalBalance: 5,
-          totalLimit: 500,
-          rowCount: 1,
-          earliestResetAt: new Date("2024-02-01"),
-          deductedId: null,
-          newBalance: null,
-        },
-      ]),
-    } as never;
+    const execute = mockExecute([
+      {
+        hasUnlimited: false,
+        totalBalance: 5,
+        totalLimit: 500,
+        rowCount: 1,
+        earliestResetAt: new Date("2024-02-01"),
+        deductedId: null,
+        newBalance: null,
+      },
+    ]);
+    const transaction = vi.fn();
+    const database = { execute, transaction } as never;
 
     const result = await reportEntitlement(database, {
       amount: 10,
@@ -90,10 +84,11 @@ describe("entitlement/service", () => {
 
     expect(result.success).toBe(false);
     expect(result.balance!.remaining).toBe(5);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(transaction).not.toHaveBeenCalled();
   });
 
   it("falls back to stacked deduction when total suffices but no single row does", async () => {
-    // CTE returns: enough total, but no deductedId (no single row covers it)
     const rows = [
       {
         balance: 3,
@@ -130,20 +125,19 @@ describe("entitlement/service", () => {
         set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
       }),
     };
-    const database = {
-      execute: mockExecute([
-        {
-          hasUnlimited: false,
-          totalBalance: 7,
-          totalLimit: 7,
-          rowCount: 2,
-          earliestResetAt: new Date("2024-02-01"),
-          deductedId: null,
-          newBalance: null,
-        },
-      ]),
-      transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(txMock)),
-    } as never;
+    const execute = mockExecute([
+      {
+        hasUnlimited: false,
+        totalBalance: 7,
+        totalLimit: 7,
+        rowCount: 2,
+        earliestResetAt: new Date("2024-02-01"),
+        deductedId: null,
+        newBalance: null,
+      },
+    ]);
+    const transaction = vi.fn(async (fn: (tx: unknown) => unknown) => fn(txMock));
+    const database = { execute, transaction } as never;
 
     const result = await reportEntitlement(database, {
       amount: 5,
@@ -154,5 +148,9 @@ describe("entitlement/service", () => {
 
     expect(result.success).toBe(true);
     expect(result.balance!.remaining).toBe(2);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(txMock.select).toHaveBeenCalledTimes(1);
+    expect(txMock.update).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/paykit/src/entitlement/__tests__/entitlement.service.test.ts
+++ b/packages/paykit/src/entitlement/__tests__/entitlement.service.test.ts
@@ -111,6 +111,25 @@ describe("entitlement/service", () => {
       },
     ];
 
+    const createSelectForUpdateChain = (result: unknown) => ({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              for: vi.fn().mockResolvedValue(result),
+            }),
+          }),
+        }),
+      }),
+    });
+    const txMock = {
+      select: vi
+        .fn()
+        .mockImplementation(() => createSelectForUpdateChain(rows.map((r) => ({ ...r })))),
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+      }),
+    };
     const database = {
       execute: mockExecute([
         {
@@ -123,10 +142,7 @@ describe("entitlement/service", () => {
           newBalance: null,
         },
       ]),
-      select: vi.fn().mockImplementation(() => createSelectChain(rows.map((r) => ({ ...r })))),
-      update: vi.fn().mockReturnValue({
-        set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
-      }),
+      transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(txMock)),
     } as never;
 
     const result = await reportEntitlement(database, {

--- a/packages/paykit/src/entitlement/entitlement.service.ts
+++ b/packages/paykit/src/entitlement/entitlement.service.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull, lte, or, sql } from "drizzle-orm";
+import { type SQL, and, eq, inArray, isNull, lte, or, sql } from "drizzle-orm";
 
 import type { PayKitDatabase } from "../database";
 import { entitlement, productFeature, subscription } from "../database/schema";
@@ -81,24 +81,6 @@ function aggregateBalance(rows: ActiveEntitlementRow[]): EntitlementBalance | nu
   return { limit, remaining, resetAt, unlimited: false };
 }
 
-const sortRowsForConsumption = (rows: ActiveEntitlementRow[]): ActiveEntitlementRow[] => {
-  return [...rows].sort((left, right) => {
-    if (left.nextResetAt && right.nextResetAt) {
-      return left.nextResetAt.getTime() - right.nextResetAt.getTime();
-    }
-
-    if (left.nextResetAt) {
-      return -1;
-    }
-
-    if (right.nextResetAt) {
-      return 1;
-    }
-
-    return left.id.localeCompare(right.id);
-  });
-};
-
 /** Fetch all active entitlements for a customer+feature, with product feature metadata. */
 async function getActiveEntitlements(
   db: PayKitDatabase,
@@ -133,39 +115,42 @@ async function getActiveEntitlements(
   return rows as ActiveEntitlementRow[];
 }
 
-/** Lazy-reset any stale entitlements and return the refreshed rows. */
+/** Lazy-reset any stale entitlements in a single batch UPDATE. */
 async function resetStaleEntitlements(
   db: PayKitDatabase,
   rows: ActiveEntitlementRow[],
   now: Date,
-): Promise<ActiveEntitlementRow[]> {
-  let changed = false;
+): Promise<void> {
+  const staleRows = rows.filter(
+    (row) =>
+      row.nextResetAt && row.nextResetAt <= now && row.resetInterval && row.originalLimit != null,
+  );
+  if (staleRows.length === 0) return;
 
-  for (const row of rows) {
-    if (
-      row.nextResetAt &&
-      row.nextResetAt <= now &&
-      row.resetInterval &&
-      row.originalLimit != null
-    ) {
-      const nextReset = getNextResetAt(row.nextResetAt, now, row.resetInterval);
-      await db
-        .update(entitlement)
-        .set({
-          balance: row.originalLimit,
-          nextResetAt: nextReset,
-          updatedAt: now,
-        })
-        .where(and(eq(entitlement.id, row.id), lte(entitlement.nextResetAt, now)));
-      row.balance = row.originalLimit;
-      row.nextResetAt = nextReset;
-      changed = true;
-    }
+  const ids: string[] = [];
+  const balanceChunks: SQL[] = [sql`(case`];
+  const resetAtChunks: SQL[] = [sql`(case`];
+
+  for (const row of staleRows) {
+    const nextReset = getNextResetAt(row.nextResetAt!, now, row.resetInterval!);
+    balanceChunks.push(sql`when ${entitlement.id} = ${row.id} then ${row.originalLimit}`);
+    resetAtChunks.push(sql`when ${entitlement.id} = ${row.id} then ${nextReset}`);
+    ids.push(row.id);
+    row.balance = row.originalLimit!;
+    row.nextResetAt = nextReset;
   }
 
-  // If nothing changed, return as-is (avoid re-fetch)
-  void changed;
-  return rows;
+  balanceChunks.push(sql`end)::integer`);
+  resetAtChunks.push(sql`end)::timestamp`);
+
+  await db
+    .update(entitlement)
+    .set({
+      balance: sql.join(balanceChunks, sql.raw(" ")),
+      nextResetAt: sql.join(resetAtChunks, sql.raw(" ")),
+      updatedAt: now,
+    })
+    .where(and(inArray(entitlement.id, ids), lte(entitlement.nextResetAt, now)));
 }
 
 // check — read entitlements with lazy reset
@@ -192,81 +177,143 @@ export async function checkEntitlement(
   return { allowed: balance.remaining >= required, balance };
 }
 
-// report — lazy reset + transactional multi-row decrement
+// report — single CTE query for all common cases
 
-const MAX_REPORT_RETRIES = 3;
+type ReportQueryRow = Record<string, unknown> & {
+  hasUnlimited: boolean;
+  totalBalance: number;
+  totalLimit: number;
+  rowCount: number;
+  earliestResetAt: Date | null;
+  deductedId: string | null;
+  newBalance: number | null;
+};
 
 export async function reportEntitlement(
   database: PayKitDatabase,
   input: { amount?: number; customerId: string; featureId: string; now?: Date },
 ): Promise<ReportResult> {
   const amount = input.amount ?? 1;
+  const now = input.now ?? new Date();
 
-  for (let attempt = 0; attempt < MAX_REPORT_RETRIES; attempt++) {
-    const rows = await getActiveEntitlements(database, input.customerId, input.featureId);
-    await resetStaleEntitlements(database, rows, input.now ?? new Date());
+  // Single CTE: read active rows, try deducting from one, return aggregated info
+  const e = entitlement;
+  const s = subscription;
+  const result = await database.execute<ReportQueryRow>(sql`
+    with active as (
+      select ${e.id} as id, ${e.balance} as balance, ${e.limit} as "limit",
+             ${e.nextResetAt} as next_reset_at
+      from ${e}
+      inner join ${s} on ${e.subscriptionId} = ${s.id}
+      where ${e.customerId} = ${input.customerId}
+        and ${e.featureId} = ${input.featureId}
+        and ${s.status} in ('active', 'trialing')
+        and (${s.endedAt} is null or ${s.endedAt} > now())
+    ),
+    deducted as (
+      update ${e}
+      set "balance" = ${e.balance} - ${amount},
+          "updated_at" = ${now}
+      where ${e.id} = (
+        select id from active
+        where balance >= ${amount} and "limit" is not null
+        limit 1
+      )
+      and not exists (select 1 from active where "limit" is null)
+      returning ${e.id} as id, ${e.balance} as balance
+    )
+    select
+      coalesce(bool_or(active."limit" is null), false) as "hasUnlimited",
+      coalesce(sum(active.balance)::integer, 0) as "totalBalance",
+      coalesce(sum(active."limit")::integer, 0) as "totalLimit",
+      count(active.*)::integer as "rowCount",
+      min(active.next_reset_at) as "earliestResetAt",
+      d.id as "deductedId",
+      d.balance as "newBalance"
+    from active
+    left join deducted d on true
+    group by d.id, d.balance
+  `);
 
-    if (rows.length === 0) {
-      return { balance: null, success: false };
-    }
-
-    const hasUnlimited = rows.some((row) => row.originalLimit === null);
-    if (hasUnlimited) {
-      return { balance: aggregateBalance(rows), success: true };
-    }
-
-    const totalBalance = rows.reduce((sum, row) => sum + row.balance, 0);
-    if (totalBalance < amount) {
-      return { balance: aggregateBalance(rows), success: false };
-    }
-
-    const result = await deductAcrossRows(database, rows, amount);
-    if (result) return result;
+  const row = result.rows[0];
+  if (!row || row.rowCount === 0) {
+    return { balance: null, success: false };
   }
 
-  // All retries exhausted due to concurrent modifications
-  const rows = await getActiveEntitlements(database, input.customerId, input.featureId);
-  return { balance: aggregateBalance(rows), success: false };
+  if (row.hasUnlimited) {
+    return {
+      balance: { limit: 0, remaining: 0, resetAt: null, unlimited: true },
+      success: true,
+    };
+  }
+
+  // Fast path succeeded — single row had enough balance
+  if (row.deductedId) {
+    const remaining = row.totalBalance - amount;
+    return {
+      balance: {
+        limit: row.totalLimit,
+        remaining,
+        resetAt: row.earliestResetAt,
+        unlimited: false,
+      },
+      success: true,
+    };
+  }
+
+  const balance: EntitlementBalance = {
+    limit: row.totalLimit,
+    remaining: row.totalBalance,
+    resetAt: row.earliestResetAt,
+    unlimited: false,
+  };
+
+  if (row.totalBalance < amount) {
+    return { balance, success: false };
+  }
+
+  // Stacked case: total is enough but no single row covers it — fall back
+  return reportEntitlementStacked(database, input.customerId, input.featureId, amount, now);
 }
 
-/** Deduct amount across sorted rows in a transaction. Returns null on conflict to signal retry. */
-async function deductAcrossRows(
+/** Fallback for stacked rows where no single row covers the amount. */
+async function reportEntitlementStacked(
   database: PayKitDatabase,
-  rows: ActiveEntitlementRow[],
+  customerId: string,
+  featureId: string,
   amount: number,
-): Promise<ReportResult | null> {
-  try {
-    await database.transaction(async (tx) => {
-      let remaining = amount;
+  now: Date,
+): Promise<ReportResult> {
+  const rows = await getActiveEntitlements(database, customerId, featureId);
+  await resetStaleEntitlements(database, rows, now);
 
-      for (const row of sortRowsForConsumption(rows)) {
-        if (remaining === 0) break;
-        if (row.originalLimit === null || row.balance <= 0) continue;
-
-        const deduction = Math.min(row.balance, remaining);
-        const result = await tx
-          .update(entitlement)
-          .set({
-            balance: sql`${entitlement.balance} - ${deduction}`,
-            updatedAt: new Date(),
-          })
-          .where(and(eq(entitlement.id, row.id), sql`${entitlement.balance} >= ${deduction}`))
-          .returning({ balance: entitlement.balance });
-
-        if (result.length === 0) {
-          throw new ConflictError();
-        }
-
-        row.balance = result[0]!.balance!;
-        remaining -= deduction;
-      }
-    });
-  } catch (error) {
-    if (error instanceof ConflictError) return null;
-    throw error;
+  const totalBalance = rows.reduce((sum, r) => sum + r.balance, 0);
+  if (totalBalance < amount) {
+    return { balance: aggregateBalance(rows), success: false };
   }
+
+  // Compute per-row target balances: greedily deduct from each row
+  const ids: string[] = [];
+  const chunks: SQL[] = [sql`(case`];
+  let remaining = amount;
+
+  for (const row of rows) {
+    if (row.originalLimit === null || row.balance <= 0) continue;
+    const deduction = Math.min(row.balance, remaining);
+    const target = row.balance - deduction;
+    chunks.push(sql`when ${entitlement.id} = ${row.id} then ${target}`);
+    ids.push(row.id);
+    row.balance = target;
+    remaining -= deduction;
+  }
+
+  chunks.push(sql`end)::integer`);
+
+  // Single CASE UPDATE: set each row to its computed target balance
+  await database
+    .update(entitlement)
+    .set({ balance: sql.join(chunks, sql.raw(" ")), updatedAt: now })
+    .where(inArray(entitlement.id, ids));
 
   return { balance: aggregateBalance(rows), success: true };
 }
-
-class ConflictError extends Error {}

--- a/packages/paykit/src/entitlement/entitlement.service.ts
+++ b/packages/paykit/src/entitlement/entitlement.service.ts
@@ -196,12 +196,15 @@ export async function reportEntitlement(
   const amount = input.amount ?? 1;
   const now = input.now ?? new Date();
 
-  // Single CTE: read active rows, try deducting from one, return aggregated info
+  // Single CTE: read active rows with lazy-reset balances, try deducting from one
   const e = entitlement;
   const s = subscription;
   const result = await database.execute<ReportQueryRow>(sql`
     with active as (
-      select ${e.id} as id, ${e.balance} as balance, ${e.limit} as "limit",
+      select ${e.id} as id,
+             case when ${e.nextResetAt} <= ${now} and ${e.limit} is not null
+               then ${e.limit} else ${e.balance} end as balance,
+             ${e.limit} as "limit",
              ${e.nextResetAt} as next_reset_at
       from ${e}
       inner join ${s} on ${e.subscriptionId} = ${s.id}
@@ -219,6 +222,7 @@ export async function reportEntitlement(
         where balance >= ${amount} and "limit" is not null
         limit 1
       )
+      and ${e.balance} >= ${amount}
       and not exists (select 1 from active where "limit" is null)
       returning ${e.id} as id, ${e.balance} as balance
     )
@@ -284,36 +288,64 @@ async function reportEntitlementStacked(
   amount: number,
   now: Date,
 ): Promise<ReportResult> {
-  const rows = await getActiveEntitlements(database, customerId, featureId);
-  await resetStaleEntitlements(database, rows, now);
+  return database.transaction(async (tx) => {
+    // Lock rows with FOR UPDATE to prevent concurrent stacked deductions
+    const rows = (await tx
+      .select({
+        id: entitlement.id,
+        balance: entitlement.balance,
+        nextResetAt: entitlement.nextResetAt,
+        originalLimit: productFeature.limit,
+        resetInterval: productFeature.resetInterval,
+      })
+      .from(entitlement)
+      .innerJoin(subscription, eq(entitlement.subscriptionId, subscription.id))
+      .innerJoin(
+        productFeature,
+        and(
+          eq(productFeature.productInternalId, subscription.productInternalId),
+          eq(productFeature.featureId, entitlement.featureId),
+        ),
+      )
+      .where(
+        and(
+          eq(entitlement.customerId, customerId),
+          eq(entitlement.featureId, featureId),
+          inArray(subscription.status, ["active", "trialing"]),
+          or(isNull(subscription.endedAt), sql`${subscription.endedAt} > now()`),
+        ),
+      )
+      .for("update", { of: entitlement })) as ActiveEntitlementRow[];
 
-  const totalBalance = rows.reduce((sum, r) => sum + r.balance, 0);
-  if (totalBalance < amount) {
-    return { balance: aggregateBalance(rows), success: false };
-  }
+    await resetStaleEntitlements(tx, rows, now);
 
-  // Compute per-row target balances: greedily deduct from each row
-  const ids: string[] = [];
-  const chunks: SQL[] = [sql`(case`];
-  let remaining = amount;
+    const totalBalance = rows.reduce((sum, r) => sum + r.balance, 0);
+    if (totalBalance < amount) {
+      return { balance: aggregateBalance(rows), success: false };
+    }
 
-  for (const row of rows) {
-    if (row.originalLimit === null || row.balance <= 0) continue;
-    const deduction = Math.min(row.balance, remaining);
-    const target = row.balance - deduction;
-    chunks.push(sql`when ${entitlement.id} = ${row.id} then ${target}`);
-    ids.push(row.id);
-    row.balance = target;
-    remaining -= deduction;
-  }
+    // Compute per-row target balances: greedily deduct from each row
+    const ids: string[] = [];
+    const chunks: SQL[] = [sql`(case`];
+    let remaining = amount;
 
-  chunks.push(sql`end)::integer`);
+    for (const row of rows) {
+      if (row.originalLimit === null || row.balance <= 0) continue;
+      const deduction = Math.min(row.balance, remaining);
+      const target = row.balance - deduction;
+      chunks.push(sql`when ${entitlement.id} = ${row.id} then ${target}`);
+      ids.push(row.id);
+      row.balance = target;
+      remaining -= deduction;
+    }
 
-  // Single CASE UPDATE: set each row to its computed target balance
-  await database
-    .update(entitlement)
-    .set({ balance: sql.join(chunks, sql.raw(" ")), updatedAt: now })
-    .where(inArray(entitlement.id, ids));
+    chunks.push(sql`end)::integer`);
 
-  return { balance: aggregateBalance(rows), success: true };
+    await tx
+      .update(entitlement)
+      .set({ balance: sql.join(chunks, sql.raw(" ")), updatedAt: now })
+      .where(inArray(entitlement.id, ids));
+
+    return { balance: aggregateBalance(rows), success: true };
+  });
 }


### PR DESCRIPTION
## Summary

- Replace multi-call SELECT + transaction + per-row UPDATE with a single PostgreSQL CTE that reads, deducts, and returns aggregated balance in one round-trip
- Common path (single row, enough balance): **1 DB call** instead of 5-7
- Stacked fallback: single CASE UPDATE instead of drain + refund (2 calls instead of 4)
- Batch stale reset: single CASE UPDATE instead of per-row updates
- Race-condition-free on the common path (single atomic statement)

## Performance

| Scenario | Before | After |
|----------|--------|-------|
| Success (1 row) | 5-7 calls | **1 call** |
| Insufficient balance | 3-5 calls | **1 call** |
| Unlimited feature | 3-5 calls | **1 call** |
| Stacked (cross-group) | 5-7 calls | **2 calls** |

## Test plan

- [ ] All 7 unit tests pass (entitlement + customer service)
- [ ] All 18 automated e2e tests pass against real Stripe
- [ ] Stacked metered e2e test verifies cross-group aggregation and consumption

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved entitlement deduction for faster, more reliable balance updates with a deterministic fallback for complex multi-row deductions and simplified conflict/retry behavior.

* **Tests**
  * Updated entitlement service tests to cover single-step deduction, unlimited-feature handling, insufficient-balance failure, and the stacked-deduction fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->