### PR TITLE
feat(cli): overhaul init with multi-framework support

### DIFF
--- a/e2e/cli/init.test.ts
+++ b/e2e/cli/init.test.ts
@@ -23,8 +23,8 @@ async function createInitFixture() {
   );
 
   // Create src directory (Next.js-like structure)
-  await fs.mkdir(path.join(cwd, "src", "app", "api", "paykit", "[...all]"), { recursive: true });
-  await fs.mkdir(path.join(cwd, "src", "server"), { recursive: true });
+  await fs.mkdir(path.join(cwd, "src", "app", "api", "paykit", "[...slug]"), { recursive: true });
+  await fs.mkdir(path.join(cwd, "src", "lib"), { recursive: true });
 
   return { cwd };
 }
@@ -33,30 +33,26 @@ describe("paykitjs init", () => {
   it("should generate config, plans, route handler, and .env", async () => {
     const { cwd } = await createInitFixture();
 
-    // Run the CLI init command non-interactively by writing the files directly
-    // (same as what initAction does after collecting answers)
-    // We test the file generation logic by importing and calling the generators
-    const configPath = "src/server/paykit.ts";
-    const plansPath = "src/server/paykit.plans.ts";
-    const routePath = "src/app/api/paykit/[...all]/route.ts";
+    const configPath = "src/lib/paykit.ts";
+    const plansPath = "src/lib/paykit-plans.ts";
+    const routePath = "src/app/api/paykit/[...slug]/route.ts";
     const envPath = ".env";
 
     // Write config file
     const configContent = `import { stripe } from "@paykitjs/stripe";
 import { createPayKit } from "paykitjs";
-import { Pool } from "pg";
-
-import * as plans from "./paykit.plans";
-
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+import { free, pro } from "./paykit-plans";
 
 export const paykit = createPayKit({
-  database: pool,
+  database: process.env.DATABASE_URL!,
   provider: stripe({
     secretKey: process.env.STRIPE_SECRET_KEY!,
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET!,
   }),
-  plans,
+  plans: [free, pro],
+  identify: async (request) => {
+    return null;
+  },
 });
 `;
 
@@ -64,11 +60,11 @@ export const paykit = createPayKit({
     await fs.mkdir(path.dirname(configFullPath), { recursive: true });
     await fs.writeFile(configFullPath, configContent);
 
-    // Verify file was created with correct content
     const written = await fs.readFile(configFullPath, "utf-8");
     expect(written).toContain("createPayKit");
     expect(written).toContain("@paykitjs/stripe");
-    expect(written).toContain("paykit.plans");
+    expect(written).toContain("paykit-plans");
+    expect(written).toContain("plans: [free, pro]");
 
     // Write plans file
     const plansContent = `import { plan } from "paykitjs";
@@ -84,7 +80,7 @@ export const pro = plan({
   id: "pro",
   name: "Pro",
   group: "base",
-  price: { amount: 2000, interval: "month" },
+  price: { amount: 29, interval: "month" },
 });
 `;
     await fs.writeFile(path.join(cwd, plansPath), plansContent);
@@ -95,8 +91,7 @@ export const pro = plan({
 
     // Write route handler
     const routeContent = `import { paykitHandler } from "paykitjs/handlers/next";
-
-import { paykit } from "../../../../server/paykit";
+import { paykit } from "@/lib/paykit";
 
 export const { GET, POST } = paykitHandler(paykit);
 `;
@@ -109,11 +104,8 @@ export const { GET, POST } = paykitHandler(paykit);
     expect(writtenRoute).toContain("GET, POST");
 
     // Write .env
-    const envContent = `# PostgreSQL connection string
-DATABASE_URL=
-# Stripe secret key (sk_test_... or sk_live_...)
+    const envContent = `DATABASE_URL=
 STRIPE_SECRET_KEY=
-# Stripe webhook secret (whsec_...)
 STRIPE_WEBHOOK_SECRET=
 `;
     await fs.writeFile(path.join(cwd, envPath), envContent);
@@ -127,11 +119,10 @@ STRIPE_WEBHOOK_SECRET=
   it("should not overwrite existing config files", async () => {
     const { cwd } = await createInitFixture();
 
-    const configPath = path.join(cwd, "src", "server", "paykit.ts");
+    const configPath = path.join(cwd, "src", "lib", "paykit.ts");
     await fs.mkdir(path.dirname(configPath), { recursive: true });
     await fs.writeFile(configPath, "// existing config\n");
 
-    // Verify the file still has the original content
     const content = await fs.readFile(configPath, "utf-8");
     expect(content).toBe("// existing config\n");
   });
@@ -142,10 +133,8 @@ STRIPE_WEBHOOK_SECRET=
     const envPath = path.join(cwd, ".env");
     await fs.writeFile(envPath, "DATABASE_URL=postgres://localhost/test\n");
 
-    // Read back and verify DATABASE_URL is present
     const content = await fs.readFile(envPath, "utf-8");
     expect(content).toContain("DATABASE_URL=postgres://localhost/test");
-    // Should only appear once
     expect(content.split("DATABASE_URL=").length - 1).toBe(1);
   });
 });

--- a/packages/paykit/src/cli/commands/init.ts
+++ b/packages/paykit/src/cli/commands/init.ts
@@ -242,9 +242,15 @@ async function initAction(options: { cwd: string; defaults: boolean }): Promise<
     const missingPerFile = getMissingEnvVars(parsed, envVarsToAdd);
 
     if (missingPerFile.length > 0) {
+      for (const { file, missing } of missingPerFile) {
+        if (missing.length === 0) continue;
+        updateEnvFiles(
+          [file],
+          missing.map((key) => `${key}=`),
+        );
+      }
+
       const allMissing = [...new Set(missingPerFile.flatMap((f) => f.missing))];
-      const lines = allMissing.map((key) => `${key}=`);
-      updateEnvFiles(envFiles, lines);
       const varList = allMissing.map((v) => `  ${picocolors.dim(`${v}=`)}`).join("\n");
       p.log.success(`Added missing env vars:\n${varList}`);
     }
@@ -362,7 +368,7 @@ async function initAction(options: { cwd: string; defaults: boolean }): Promise<
 
   // ── Pricing template (skip if plans file exists) ──
 
-  const plansPath = configPath.replace(/paykit\.ts$/, "paykit-plans.ts");
+  const plansPath = configPath.replace(/paykit(\.config)?\.ts$/, "paykit-plans.ts");
   const plansFullPath = path.join(cwd, plansPath);
   let templateId: string | symbol = "saas-starter";
 

--- a/packages/paykit/src/cli/commands/init.ts
+++ b/packages/paykit/src/cli/commands/init.ts
@@ -187,8 +187,6 @@ async function initAction(options: { cwd: string; defaults: boolean }): Promise<
     process.exit(1);
   }
 
-  // ── Auto-detect framework (before anything else) ──
-
   const detectedFramework = detectFramework(cwd);
 
   if (!detectedFramework) {
@@ -213,8 +211,6 @@ async function initAction(options: { cwd: string; defaults: boolean }): Promise<
   const existingConfig = findExistingFile(cwd, POSSIBLE_CONFIG_PATHS);
   const existingClient = findExistingFile(cwd, POSSIBLE_CLIENT_PATHS);
 
-  // ── Provider selection (skip if already initialized) ──
-
   let provider: string | symbol = "stripe";
   if (!existingConfig && !useDefaults) {
     provider = await p.select({
@@ -231,8 +227,6 @@ async function initAction(options: { cwd: string; defaults: boolean }): Promise<
       process.exit(0);
     }
   }
-
-  // ── Environment variables ──
 
   const envFiles = getEnvFiles(cwd);
   const envVarsToAdd = ENV_VARS.map((v) => v.key);
@@ -272,8 +266,6 @@ async function initAction(options: { cwd: string; defaults: boolean }): Promise<
     } as Framework;
   }
 
-  // ── Config file path (skip if exists) ──
-
   const configDefault = defaultConfigPath(cwd);
   let configPath: string;
   if (existingConfig) {
@@ -299,8 +291,6 @@ async function initAction(options: { cwd: string; defaults: boolean }): Promise<
     }
     configPath = result;
   }
-
-  // ── Route handler (skip if exists) ──
 
   let routePath: string | null = null;
   if (framework.routeHandler) {
@@ -330,8 +320,6 @@ async function initAction(options: { cwd: string; defaults: boolean }): Promise<
       "Manual Setup",
     );
   }
-
-  // ── Client (skip if exists) ──
 
   let clientPath: string | null = null;
   if (!existingClient && framework.authClient) {
@@ -366,8 +354,6 @@ async function initAction(options: { cwd: string; defaults: boolean }): Promise<
     }
   }
 
-  // ── Pricing template (skip if plans file exists) ──
-
   const plansPath = configPath.replace(/paykit(\.config)?\.ts$/, "paykit-plans.ts");
   const plansFullPath = path.join(cwd, plansPath);
   let templateId: string | symbol = "saas-starter";
@@ -387,8 +373,6 @@ async function initAction(options: { cwd: string; defaults: boolean }): Promise<
       process.exit(0);
     }
   }
-
-  // ── Install dependencies ──
 
   const packages = ["paykitjs", "@paykitjs/stripe"];
   const toInstall = packages.filter((pkg) => !isPackageInstalled(cwd, pkg));
@@ -410,8 +394,6 @@ async function initAction(options: { cwd: string; defaults: boolean }): Promise<
       p.log.message(`  ${picocolors.dim(msg)}\n  Run manually: ${picocolors.bold(installCmd)}`);
     }
   }
-
-  // ── Generate files ──
 
   const files: FileToWrite[] = [];
 

--- a/packages/paykit/src/cli/commands/init.ts
+++ b/packages/paykit/src/cli/commands/init.ts
@@ -1,4 +1,8 @@
-import { execSync } from "node:child_process";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
 import fs from "node:fs";
 import path from "node:path";
 
@@ -6,15 +10,26 @@ import * as p from "@clack/prompts";
 import { Command } from "commander";
 import picocolors from "picocolors";
 
+import type { Framework } from "../configs/frameworks.config";
 import { templates } from "../templates/index";
 import {
   defaultConfigPath,
-  defaultRoutePath,
+  detectFramework,
+  detectNextJsRouterPath,
   detectPackageManager,
+  getDlxPrefix,
+  getExecPrefix,
   getInstallCommand,
   isPackageInstalled,
   resolveImportPath,
 } from "../utils/detect";
+import {
+  createEnvFile,
+  getEnvFiles,
+  getMissingEnvVars,
+  parseEnvFiles,
+  updateEnvFiles,
+} from "../utils/env";
 import { capture } from "../utils/telemetry";
 
 function ensureDir(filePath: string): void {
@@ -24,77 +39,103 @@ function ensureDir(filePath: string): void {
   }
 }
 
-function generateConfigFile(): string {
+const POSSIBLE_CONFIG_PATHS = buildPossiblePaths(["paykit.ts", "paykit.config.ts"]);
+const POSSIBLE_CLIENT_PATHS = buildPossiblePaths(["paykit-client.ts"]);
+
+function buildPossiblePaths(basePaths: string[]): string[] {
+  const dirs = ["", "lib/", "server/", "utils/"];
+  const withDirs = dirs.flatMap((dir) => basePaths.map((p) => `${dir}${p}`));
+  return [...withDirs, ...withDirs.map((p) => `src/${p}`)];
+}
+
+function findExistingFile(cwd: string, candidates: string[]): string | null {
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(cwd, candidate))) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function generateConfigFile(templateId: string, includeIdentify: boolean): string {
+  const planImports =
+    templateId === "saas-starter" ? "free, pro" : templateId === "usage-based" ? "free, pro" : "";
+
+  const plansLine = planImports ? `\n  plans: [${planImports}],` : "\n  plans: [],";
+  const importLine = planImports ? `\nimport { ${planImports} } from "./paykit-plans";` : "";
+
+  const identifyBlock = includeIdentify
+    ? `
+  identify: async (request) => {
+    // Replace with your auth logic, for example:
+    // const session = await auth.api.getSession({ headers: request.headers });
+    // if (!session) return null;
+    // return {
+    //   customerId: session.user.id,
+    //   email: session.user.email,
+    //   name: session.user.name,
+    // };
+    return null;
+  },`
+    : "";
+
   return `import { stripe } from "@paykitjs/stripe";
-import { createPayKit } from "paykitjs";
-import { Pool } from "pg";
-
-import * as plans from "./paykit.plans";
-
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+import { createPayKit } from "paykitjs";${importLine}
 
 export const paykit = createPayKit({
-  database: pool,
+  database: process.env.DATABASE_URL!,
   provider: stripe({
     secretKey: process.env.STRIPE_SECRET_KEY!,
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET!,
-  }),
-  plans,
+  }),${plansLine}${identifyBlock}
 });
 `;
 }
 
-function generateRouteHandler(configPath: string, routePath: string, cwd: string): string {
-  const configFullPath = path.join(cwd, configPath);
-  const routeFullPath = path.join(cwd, routePath);
-  const importPath = resolveImportPath(routeFullPath, configFullPath, cwd);
+function generateRouteHandler(
+  configPath: string,
+  routePath: string,
+  cwd: string,
+  framework: Framework,
+): string {
+  if (!framework.routeHandler) return "";
 
-  return `import { paykitHandler } from "paykitjs/handlers/next";
+  const importPath = resolveImportPath(routePath, configPath, cwd, framework);
 
-import { paykit } from "${importPath}";
+  let code: string = framework.routeHandler.code;
+  const importPatterns = [
+    /from\s+["']@\/[^"']+["']/,
+    /from\s+["']~\/[^"']+["']/,
+    /from\s+["']\$lib\/[^"']+["']/,
+    /from\s+["']\.\/[^"']+["']/,
+    /from\s+["']\.\.\/[^"']+["']/,
+  ];
 
-export const { GET, POST } = paykitHandler(paykit);
-`;
+  for (const pattern of importPatterns) {
+    const replaced = code.replace(pattern, `from "${importPath}"`);
+    if (replaced !== code) {
+      code = replaced;
+      break;
+    }
+  }
+
+  return code + "\n";
 }
 
-function generateClientFile(configPath: string, clientPath: string, cwd: string): string {
-  const configFullPath = path.join(cwd, configPath);
-  const clientFullPath = path.join(cwd, clientPath);
-  const importPath = resolveImportPath(clientFullPath, configFullPath, cwd);
+function generateClientFile(
+  configPath: string,
+  clientPath: string,
+  cwd: string,
+  framework: Framework,
+): string {
+  const importPath = resolveImportPath(clientPath, configPath, cwd, framework);
+  const clientImport = framework.authClient?.importPath ?? "paykitjs/client";
 
-  return `import { createPayKitClient } from "paykitjs/client";
-
+  return `import { createPayKitClient } from "${clientImport}";
 import type { paykit } from "${importPath}";
 
 export const paykitClient = createPayKitClient<typeof paykit>();
 `;
-}
-
-function getEnvVarsToAdd(cwd: string): { key: string; comment: string }[] {
-  const envPath = path.join(cwd, ".env");
-  const existing = fs.existsSync(envPath) ? fs.readFileSync(envPath, "utf-8") : "";
-
-  const vars = [
-    { key: "DATABASE_URL", comment: "# PostgreSQL connection string" },
-    { key: "STRIPE_SECRET_KEY", comment: "# Stripe secret key (sk_test_... or sk_live_...)" },
-    { key: "STRIPE_WEBHOOK_SECRET", comment: "# Stripe webhook secret (whsec_...)" },
-  ];
-
-  return vars.filter((v) => !existing.includes(`${v.key}=`));
-}
-
-function writeEnvVars(cwd: string, vars: { key: string; comment: string }[]): void {
-  const envPath = path.join(cwd, ".env");
-  let content = fs.existsSync(envPath) ? fs.readFileSync(envPath, "utf-8") : "";
-
-  for (const v of vars) {
-    if (content.length > 0 && !content.endsWith("\n")) {
-      content += "\n";
-    }
-    content += `${v.comment}\n${v.key}=\n`;
-  }
-
-  fs.writeFileSync(envPath, content);
 }
 
 interface FileToWrite {
@@ -102,116 +143,247 @@ interface FileToWrite {
   content: string;
 }
 
-async function initAction(options: { cwd: string }): Promise<void> {
+const ENV_VARS = [
+  { key: "DATABASE_URL", line: "DATABASE_URL=" },
+  { key: "STRIPE_SECRET_KEY", line: "STRIPE_SECRET_KEY=" },
+  { key: "STRIPE_WEBHOOK_SECRET", line: "STRIPE_WEBHOOK_SECRET=" },
+];
+
+function frameworksList(): string {
+  const c = picocolors.cyan;
+  const dot = picocolors.dim(" · ");
+  const row1 = ["Next.js", "Tanstack Start", "Hono", "Express", "Elysia"].map(c).join(dot);
+  const row2 = [
+    "Remix",
+    "Astro",
+    "SvelteKit",
+    "Nuxt",
+    "Solid Start",
+    "React Router",
+    "Fastify",
+    "Nitro",
+  ]
+    .map(c)
+    .join(dot);
+  return [`   ${picocolors.bold("Supported frameworks:")}`, `     ${row1}`, `     ${row2}`].join(
+    "\n",
+  );
+}
+
+async function initAction(options: { cwd: string; defaults: boolean }): Promise<void> {
   const cwd = path.resolve(options.cwd);
+  const useDefaults = options.defaults;
 
-  p.intro("paykit init");
-  p.log.info("Welcome to PayKit! Let's set up billing.");
-
-  // ── Collect answers ──
-
-  // 1. Provider selection
-  const provider = await p.select({
-    message: "Select a payment provider",
-    options: [
-      { value: "stripe", label: "Stripe" },
-      { value: "polar", label: "Polar", hint: "coming soon", disabled: true },
-      { value: "creem", label: "Creem", hint: "coming soon", disabled: true },
-    ],
-  });
-
-  if (p.isCancel(provider)) {
-    p.cancel("Aborted");
-    process.exit(0);
+  if (!fs.existsSync(path.join(cwd, "package.json"))) {
+    p.outro(
+      [
+        picocolors.red("PayKit must be initialized inside a project."),
+        "",
+        "   No package.json found in this directory.",
+        "",
+        frameworksList(),
+      ].join("\n"),
+    );
+    process.exit(1);
   }
 
-  // 2. Config path
+  // ── Auto-detect framework (before anything else) ──
+
+  const detectedFramework = detectFramework(cwd);
+
+  if (!detectedFramework) {
+    p.outro(
+      [
+        picocolors.red("Could not detect a supported framework."),
+        "",
+        "   Make sure you're running this inside your app directory, not the monorepo root.",
+        "",
+        frameworksList(),
+      ].join("\n"),
+    );
+    process.exit(1);
+  }
+
+  p.intro(picocolors.cyan("Welcome to PayKit! Let's set up billing."));
+
+  let framework: Framework = detectedFramework;
+  p.log.step(`Detected framework: ${picocolors.bold(framework.name)}`);
+
+  // Check what already exists
+  const existingConfig = findExistingFile(cwd, POSSIBLE_CONFIG_PATHS);
+  const existingClient = findExistingFile(cwd, POSSIBLE_CLIENT_PATHS);
+
+  // ── Provider selection (skip if already initialized) ──
+
+  let provider: string | symbol = "stripe";
+  if (!existingConfig && !useDefaults) {
+    provider = await p.select({
+      message: "Select payment provider",
+      options: [
+        { value: "stripe", label: "Stripe" },
+        { value: "polar", label: "Polar", hint: "coming soon", disabled: true },
+        { value: "creem", label: "Creem", hint: "coming soon", disabled: true },
+      ],
+    });
+
+    if (p.isCancel(provider)) {
+      p.cancel("Aborted");
+      process.exit(0);
+    }
+  }
+
+  // ── Environment variables ──
+
+  const envFiles = getEnvFiles(cwd);
+  const envVarsToAdd = ENV_VARS.map((v) => v.key);
+
+  if (envFiles.length > 0) {
+    const parsed = parseEnvFiles(envFiles);
+    const missingPerFile = getMissingEnvVars(parsed, envVarsToAdd);
+
+    if (missingPerFile.length > 0) {
+      const allMissing = [...new Set(missingPerFile.flatMap((f) => f.missing))];
+      const lines = allMissing.map((key) => `${key}=`);
+      updateEnvFiles(envFiles, lines);
+      const varList = allMissing.map((v) => `  ${picocolors.dim(`${v}=`)}`).join("\n");
+      p.log.success(`Added missing env vars:\n${varList}`);
+    }
+  } else {
+    const lines = ENV_VARS.map((v) => v.line);
+    createEnvFile(cwd, lines);
+    p.log.success(`Created .env with ${String(ENV_VARS.length)} variables`);
+  }
+
+  // For Next.js, detect App Router vs Pages Router
+  if (framework.id === "next" && framework.routeHandler) {
+    const routeHandlerPath = detectNextJsRouterPath(cwd);
+    framework = {
+      ...framework,
+      routeHandler: {
+        ...framework.routeHandler,
+        path: routeHandlerPath,
+      },
+    } as Framework;
+  }
+
+  // ── Config file path (skip if exists) ──
+
   const configDefault = defaultConfigPath(cwd);
-  const configPath = await p.text({
-    message: "Where should we create the PayKit config?",
-    defaultValue: configDefault,
-    placeholder: configDefault,
-  });
+  let configPath: string;
+  if (existingConfig) {
+    configPath = existingConfig;
+  } else if (useDefaults) {
+    configPath = configDefault;
+  } else {
+    const result = await p.text({
+      message: "Path for the PayKit instance",
+      defaultValue: configDefault,
+      placeholder: configDefault,
+      validate: (value) => {
+        const v = value || configDefault;
+        if (!v.endsWith("/paykit.ts") && v !== "paykit.ts") return "Filename must be paykit.ts";
+        if (v.startsWith("/")) return "Path must be relative";
+        return undefined;
+      },
+    });
 
-  if (p.isCancel(configPath)) {
-    p.cancel("Aborted");
-    process.exit(0);
+    if (p.isCancel(result)) {
+      p.cancel("Aborted");
+      process.exit(0);
+    }
+    configPath = result;
   }
 
-  // 3. Route handler
-  const framework = await p.select({
-    message: "Framework",
-    options: [
-      { value: "nextjs", label: "Next.js (App Router)" },
-      { value: "other", label: "Other", hint: "not yet supported" },
-    ],
-  });
-
-  if (p.isCancel(framework)) {
-    p.cancel("Aborted");
-    process.exit(0);
-  }
+  // ── Route handler (skip if exists) ──
 
   let routePath: string | null = null;
-  if (framework === "nextjs") {
-    const routeDefault = defaultRoutePath(cwd);
-    const result = await p.text({
-      message: "Route handler path",
-      defaultValue: routeDefault,
-      placeholder: routeDefault,
-    });
+  if (framework.routeHandler) {
+    const routeDefault = framework.routeHandler.path;
+    const routeFullPath = path.join(cwd, routeDefault);
 
-    if (p.isCancel(result)) {
-      p.cancel("Aborted");
-      process.exit(0);
+    if (!fs.existsSync(routeFullPath)) {
+      if (useDefaults) {
+        routePath = routeDefault;
+      } else {
+        const result = await p.text({
+          message: "Path for the route handler",
+          defaultValue: routeDefault,
+          placeholder: routeDefault,
+        });
+
+        if (p.isCancel(result)) {
+          p.cancel("Aborted");
+          process.exit(0);
+        }
+        routePath = result;
+      }
     }
-    routePath = result;
+  } else if (!existingConfig) {
+    p.note(
+      "See the docs for manual route handler setup:\nhttps://paykitjs.com/docs/setup",
+      "Manual Setup",
+    );
   }
 
-  // 4. Client
-  const generateClient = await p.confirm({
-    message: "Generate a PayKit client?",
-  });
-
-  if (p.isCancel(generateClient)) {
-    p.cancel("Aborted");
-    process.exit(0);
-  }
+  // ── Client (skip if exists) ──
 
   let clientPath: string | null = null;
-  if (generateClient) {
-    const clientDefault = "src/lib/paykit-client.ts";
-    const result = await p.text({
-      message: "Client file path",
-      defaultValue: clientDefault,
-      placeholder: clientDefault,
+  if (!existingClient && framework.authClient) {
+    const configDir = path.dirname(configPath);
+    const clientDefault = path.join(configDir, "paykit-client.ts");
+
+    if (useDefaults) {
+      clientPath = clientDefault;
+    } else {
+      const generateClient = await p.confirm({
+        message: "Wanna use PayKit client caller?",
+      });
+
+      if (p.isCancel(generateClient)) {
+        p.cancel("Aborted");
+        process.exit(0);
+      }
+
+      if (generateClient) {
+        const result = await p.text({
+          message: "Path for the client instance",
+          defaultValue: clientDefault,
+          placeholder: clientDefault,
+        });
+
+        if (p.isCancel(result)) {
+          p.cancel("Aborted");
+          process.exit(0);
+        }
+        clientPath = result;
+      }
+    }
+  }
+
+  // ── Pricing template (skip if plans file exists) ──
+
+  const plansPath = configPath.replace(/paykit\.ts$/, "paykit-plans.ts");
+  const plansFullPath = path.join(cwd, plansPath);
+  let templateId: string | symbol = "saas-starter";
+
+  if (!fs.existsSync(plansFullPath) && !useDefaults) {
+    templateId = await p.select({
+      message: "Select pricing template",
+      options: templates.map((t) => ({
+        value: t.id,
+        label: t.name,
+        hint: t.hint,
+      })),
     });
 
-    if (p.isCancel(result)) {
+    if (p.isCancel(templateId)) {
       p.cancel("Aborted");
       process.exit(0);
     }
-    clientPath = result;
   }
 
-  // 5. Products template
-  const templateId = await p.select({
-    message: "Select a pricing template",
-    options: templates.map((t) => ({
-      value: t.id,
-      label: t.name,
-      hint: t.hint,
-    })),
-  });
+  // ── Install dependencies ──
 
-  if (p.isCancel(templateId)) {
-    p.cancel("Aborted");
-    process.exit(0);
-  }
-
-  // ── Execute ──
-
-  // Install dependencies
   const packages = ["paykitjs", "@paykitjs/stripe"];
   const toInstall = packages.filter((pkg) => !isPackageInstalled(cwd, pkg));
 
@@ -219,64 +391,54 @@ async function initAction(options: { cwd: string }): Promise<void> {
     const pm = detectPackageManager(cwd);
     const installCmd = getInstallCommand(pm, toInstall);
     const spinner = p.spinner();
-    spinner.start(`Installing ${toInstall.join(", ")}`);
+    spinner.start(`Installing ${toInstall.join(", ")} via ${pm}`);
     try {
-      execSync(installCmd, {
+      await execAsync(installCmd, {
         cwd,
-        stdio: "pipe",
         env: { ...process.env, NODE_ENV: "" },
       });
-      spinner.stop(`Installed ${toInstall.join(", ")}`);
-    } catch {
-      spinner.stop("Could not install automatically");
-      p.log.step(`Add to your package.json manually:\n  ${picocolors.dim(installCmd)}`);
+      spinner.stop(`Installed ${toInstall.join(", ")} via ${pm}`);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      spinner.stop(picocolors.yellow("Could not install dependencies"));
+      p.log.message(`  ${picocolors.dim(msg)}\n  Run manually: ${picocolors.bold(installCmd)}`);
     }
-  } else {
-    p.log.step("Dependencies already installed");
   }
 
-  // Generate files
+  // ── Generate files ──
+
   const files: FileToWrite[] = [];
-  const skipped: string[] = [];
 
   // Config
-  const configFullPath = path.join(cwd, configPath);
-  if (fs.existsSync(configFullPath)) {
-    skipped.push(configPath);
-  } else {
-    files.push({ path: configPath, content: generateConfigFile() });
+  if (!existingConfig) {
+    files.push({
+      path: configPath,
+      content: generateConfigFile(templateId as string, clientPath !== null),
+    });
   }
 
   // Plans
-  const template = templates.find((t) => t.id === templateId);
-  if (template) {
-    const plansPath = configPath.replace(/paykit\.ts$/, "paykit.plans.ts");
-    const plansFullPath = path.join(cwd, plansPath);
-    if (fs.existsSync(plansFullPath)) {
-      skipped.push(plansPath);
-    } else {
+  if (!fs.existsSync(plansFullPath)) {
+    const template = templates.find((t) => t.id === templateId);
+    if (template) {
       files.push({ path: plansPath, content: template.content });
     }
   }
 
   // Route handler
   if (routePath) {
-    const routeFullPath = path.join(cwd, routePath);
-    if (fs.existsSync(routeFullPath)) {
-      skipped.push(routePath);
-    } else {
-      files.push({ path: routePath, content: generateRouteHandler(configPath, routePath, cwd) });
-    }
+    files.push({
+      path: routePath,
+      content: generateRouteHandler(configPath, routePath, cwd, framework),
+    });
   }
 
   // Client
   if (clientPath) {
-    const clientFullPath = path.join(cwd, clientPath);
-    if (fs.existsSync(clientFullPath)) {
-      skipped.push(clientPath);
-    } else {
-      files.push({ path: clientPath, content: generateClientFile(configPath, clientPath, cwd) });
-    }
+    files.push({
+      path: clientPath,
+      content: generateClientFile(configPath, clientPath, cwd, framework),
+    });
   }
 
   // Write all files
@@ -293,44 +455,44 @@ async function initAction(options: { cwd: string }): Promise<void> {
     );
   }
 
-  if (skipped.length > 0) {
-    const skipList = skipped.map((f) => `  ${picocolors.dim(f)}`).join("\n");
-    p.log.step(`Skipped (already exist):\n${skipList}`);
-  }
-
-  // Environment variables
-  const envVars = getEnvVarsToAdd(cwd);
-  if (envVars.length > 0) {
-    writeEnvVars(cwd, envVars);
-    const varList = envVars.map((v) => `  ${picocolors.dim(`${v.key}=`)}`).join("\n");
-    p.log.success(`Added to .env:\n${varList}`);
-  } else {
-    p.log.step("Environment variables already configured");
-  }
-
-  // Manual setup note for non-Next.js
-  if (framework === "other") {
-    p.note(
-      "See the docs for manual route handler setup:\nhttps://paykitjs.com/docs/setup",
-      "Manual Setup",
-    );
-  }
-
   capture("cli_command", {
     command: "init",
     provider: provider as string,
-    framework: framework as string,
+    framework: framework.id,
     template: templateId as string,
     filesCreated: files.length,
   });
 
-  // Done
-  p.note(
-    `Fill in the variables in .env, then run:\n  ${picocolors.bold("paykitjs push")}\n\nFor local webhooks:\n  ${picocolors.dim("stripe listen --forward-to localhost:3000/api/paykit")}`,
-    "Almost there!",
-  );
+  const pm = detectPackageManager(cwd);
+  const exec = getExecPrefix(pm);
+  const c = picocolors.cyan;
+  const b = picocolors.bold;
 
-  p.outro("Done");
+  const isRerun = files.length === 0;
+  const heading = isRerun
+    ? picocolors.green("PayKit is already initialized!")
+    : picocolors.green("PayKit setup completed!");
+
+  p.outro(
+    [
+      heading,
+      "",
+      `   ${b("Next steps")}`,
+      `   ${c("1.")} Fill in .env variables`,
+      `   ${c("2.")} Sync your products ${b(`${exec} paykitjs push`)}`,
+      "",
+      `   You're good to use PayKit!`,
+      "",
+      `   ${b("Commands")}`,
+      `   ${c("•")} Check status: ${b(`${exec} paykitjs status`)}`,
+      `   ${c("•")} To sync updated products: ${b(`${exec} paykitjs push`)}`,
+      `   ${c("•")} Add AI skills: ${b(`${getDlxPrefix(pm)} skills add getpaykit/skills`)}`,
+      `   ${c("•")} Forward dev webhooks: ${b("stripe listen --forward-to localhost:3000/paykit/api/webhook/stripe")}`,
+      "",
+      `   Please star us on github ${c("<3")}`,
+      `   ${c("https://paykit.sh/github")}`,
+    ].join("\n"),
+  );
 }
 
 export const initCommand = new Command("init")
@@ -340,4 +502,5 @@ export const initCommand = new Command("init")
     "the working directory. defaults to the current directory.",
     process.cwd(),
   )
+  .option("-y, --defaults", "skip prompts and use defaults", false)
   .action(initAction);

--- a/packages/paykit/src/cli/commands/init.ts
+++ b/packages/paykit/src/cli/commands/init.ts
@@ -485,7 +485,7 @@ async function initAction(options: { cwd: string; defaults: boolean }): Promise<
       "",
       `   ${b("Commands")}`,
       `   ${c("•")} Check status: ${b(`${exec} paykitjs status`)}`,
-      `   ${c("•")} To sync updated products: ${b(`${exec} paykitjs push`)}`,
+      `   ${c("•")} Sync updated products: ${b(`${exec} paykitjs push`)}`,
       `   ${c("•")} Add AI skills: ${b(`${getDlxPrefix(pm)} skills add getpaykit/skills`)}`,
       `   ${c("•")} Forward dev webhooks: ${b("stripe listen --forward-to localhost:3000/paykit/api/webhook/stripe")}`,
       "",

--- a/packages/paykit/src/cli/configs/frameworks.config.ts
+++ b/packages/paykit/src/cli/configs/frameworks.config.ts
@@ -1,0 +1,195 @@
+export const FRAMEWORKS = [
+  {
+    name: "Next.js",
+    id: "next",
+    dependency: "next",
+    authClient: {
+      importPath: "paykitjs/client",
+    },
+    routeHandler: {
+      path: "api/paykit/[...slug]/route.ts",
+      code: `import { paykitHandler } from "paykitjs/handlers/next";
+
+import { paykit } from "@/lib/paykit";
+
+export const { GET, POST } = paykitHandler(paykit);`,
+    },
+    configPaths: ["next.config.js", "next.config.ts", "next.config.mjs"],
+  },
+  {
+    name: "Nuxt",
+    id: "nuxt",
+    dependency: "nuxt",
+    authClient: {
+      importPath: "paykitjs/client",
+    },
+    routeHandler: {
+      path: "server/api/paykit/[...slug].ts",
+      code: `import { paykit } from "~/lib/paykit";
+
+export default defineEventHandler((event) => {
+  return paykit.handler(toWebRequest(event));
+});`,
+    },
+    configPaths: ["nuxt.config.js", "nuxt.config.ts", "nuxt.config.mjs", "nuxt.config.cjs"],
+  },
+  {
+    name: "SvelteKit",
+    id: "sveltekit",
+    dependency: "@sveltejs/kit",
+    authClient: {
+      importPath: "paykitjs/client",
+    },
+    routeHandler: {
+      path: "src/routes/api/paykit/[...slug]/+server.ts",
+      code: `import { paykit } from "$lib/paykit";
+
+export const GET = ({ request }) => paykit.handler(request);
+export const POST = ({ request }) => paykit.handler(request);`,
+    },
+    configPaths: ["svelte.config.js", "svelte.config.ts", "svelte.config.mjs", "svelte.config.cjs"],
+  },
+  {
+    name: "Solid Start",
+    id: "solid-start",
+    dependency: "solid-start",
+    authClient: {
+      importPath: "paykitjs/client",
+    },
+    routeHandler: {
+      path: "src/routes/api/paykit/*slug.ts",
+      code: `import { paykit } from "~/lib/paykit";
+
+export const GET = ({ request }) => paykit.handler(request);
+export const POST = ({ request }) => paykit.handler(request);`,
+    },
+    configPaths: ["app.config.ts"],
+  },
+  {
+    name: "Tanstack Start",
+    id: "tanstack-start",
+    dependency: "@tanstack/react-start",
+    authClient: {
+      importPath: "paykitjs/client",
+    },
+    routeHandler: {
+      path: "app/api/paykit.$.ts",
+      code: `import { paykit } from "@/lib/paykit";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/paykit/$")({
+  server: {
+    handlers: {
+      GET: ({ request }) => paykit.handler(request),
+      POST: ({ request }) => paykit.handler(request),
+    },
+  },
+});`,
+    },
+    configPaths: null,
+  },
+  {
+    name: "Astro",
+    id: "astro",
+    dependency: "astro",
+    authClient: {
+      importPath: "paykitjs/client",
+    },
+    routeHandler: {
+      path: "src/pages/api/paykit/[...slug].ts",
+      code: `import { paykit } from "@/lib/paykit";
+import type { APIRoute } from "astro";
+
+export const ALL: APIRoute = async (ctx) => {
+  return paykit.handler(ctx.request);
+};`,
+    },
+    configPaths: ["astro.config.mjs", "astro.config.ts", "astro.config.js", "astro.config.cjs"],
+  },
+  {
+    name: "Remix",
+    id: "remix",
+    dependency: "@remix-run/server-runtime",
+    authClient: {
+      importPath: "paykitjs/client",
+    },
+    routeHandler: {
+      path: "app/routes/api.paykit.$.ts",
+      code: `import { paykit } from "~/lib/paykit";
+
+export const loader = ({ request }) => paykit.handler(request);
+export const action = ({ request }) => paykit.handler(request);`,
+    },
+    configPaths: ["remix.config.js"],
+  },
+  {
+    name: "React Router v7",
+    id: "react-router-v7",
+    dependency: "react-router",
+    authClient: {
+      importPath: "paykitjs/client",
+    },
+    routeHandler: {
+      path: "app/routes/api.paykit.$.ts",
+      code: `import { paykit } from "~/lib/paykit";
+
+export const loader = ({ request }) => paykit.handler(request);
+export const action = ({ request }) => paykit.handler(request);`,
+    },
+    configPaths: ["react-router.config.ts"],
+  },
+  {
+    name: "Hono",
+    id: "hono",
+    dependency: "hono",
+    authClient: null,
+    routeHandler: null,
+    configPaths: null,
+  },
+  {
+    name: "Fastify",
+    id: "fastify",
+    dependency: "fastify",
+    authClient: null,
+    routeHandler: null,
+    configPaths: null,
+  },
+  {
+    name: "Express",
+    id: "express",
+    dependency: "express",
+    authClient: null,
+    routeHandler: null,
+    configPaths: null,
+  },
+  {
+    name: "Elysia",
+    id: "elysia",
+    dependency: "elysia",
+    authClient: null,
+    routeHandler: null,
+    configPaths: null,
+  },
+  {
+    name: "Nitro",
+    id: "nitro",
+    dependency: "nitro",
+    authClient: null,
+    routeHandler: null,
+    configPaths: ["nitro.config.ts"],
+  },
+] as const satisfies {
+  name: string;
+  id: string;
+  dependency: string;
+  authClient: {
+    importPath: string;
+  } | null;
+  routeHandler: {
+    path: string;
+    code: string;
+  } | null;
+  configPaths: string[] | null;
+}[];
+
+export type Framework = (typeof FRAMEWORKS)[number];

--- a/packages/paykit/src/cli/utils/detect.ts
+++ b/packages/paykit/src/cli/utils/detect.ts
@@ -1,7 +1,30 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import type { Framework } from "../configs/frameworks.config";
+import { FRAMEWORKS } from "../configs/frameworks.config";
+
 export type PackageManager = "bun" | "npm" | "pnpm" | "yarn";
+
+function getPackageManagerFromPkgJson(cwd: string): PackageManager | null {
+  const pkgPath = path.join(cwd, "package.json");
+  if (!fs.existsSync(pkgPath)) return null;
+
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as {
+      packageManager?: string;
+    };
+    const pm = pkg.packageManager;
+    if (!pm) return null;
+    if (pm.startsWith("pnpm")) return "pnpm";
+    if (pm.startsWith("yarn")) return "yarn";
+    if (pm.startsWith("bun")) return "bun";
+    if (pm.startsWith("npm")) return "npm";
+  } catch {
+    // ignore
+  }
+  return null;
+}
 
 export function detectPackageManager(cwd: string): PackageManager {
   // 1. Check npm_config_user_agent (set by the running package manager)
@@ -10,7 +33,11 @@ export function detectPackageManager(cwd: string): PackageManager {
   if (userAgent.startsWith("yarn")) return "yarn";
   if (userAgent.startsWith("bun")) return "bun";
 
-  // 2. Check lockfiles in cwd and parent dirs (monorepo support)
+  // 2. Check packageManager field in package.json
+  const pmFromPkg = getPackageManagerFromPkgJson(cwd);
+  if (pmFromPkg) return pmFromPkg;
+
+  // 3. Check lockfiles in cwd and parent dirs (monorepo support)
   let dir = cwd;
   while (true) {
     if (fs.existsSync(path.join(dir, "pnpm-lock.yaml"))) return "pnpm";
@@ -31,6 +58,20 @@ export function getInstallCommand(pm: PackageManager, packages: string[]): strin
   return `${cmd} ${packages.join(" ")}`;
 }
 
+export function getExecPrefix(pm: PackageManager): string {
+  if (pm === "npm") return "npx";
+  if (pm === "bun") return "bunx";
+  if (pm === "yarn") return "yarn";
+  return "pnpm";
+}
+
+export function getDlxPrefix(pm: PackageManager): string {
+  if (pm === "npm") return "npx";
+  if (pm === "bun") return "bunx";
+  if (pm === "yarn") return "yarn dlx";
+  return "pnpx";
+}
+
 export function isPackageInstalled(cwd: string, name: string): boolean {
   const pkgPath = path.join(cwd, "package.json");
   if (!fs.existsSync(pkgPath)) return false;
@@ -46,54 +87,187 @@ export function isPackageInstalled(cwd: string, name: string): boolean {
   }
 }
 
-export function hasTsconfigPathAlias(cwd: string): boolean {
-  const tsconfigPath = path.join(cwd, "tsconfig.json");
-  if (!fs.existsSync(tsconfigPath)) return false;
+function readPackageJson(
+  cwd: string,
+): { dependencies?: Record<string, string>; devDependencies?: Record<string, string> } | null {
+  const pkgPath = path.join(cwd, "package.json");
+  if (!fs.existsSync(pkgPath)) return null;
 
   try {
-    const raw = fs.readFileSync(tsconfigPath, "utf-8");
-    // Strip comments for JSON.parse
-    const stripped = raw.replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, "");
-    const tsconfig = JSON.parse(stripped) as {
-      compilerOptions?: { paths?: Record<string, string[]> };
+    return JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
     };
-    return Boolean(tsconfig.compilerOptions?.paths?.["@/*"]);
   } catch {
-    return false;
+    return null;
   }
 }
 
-export function resolveImportPath(fromFile: string, toFile: string, cwd: string): string {
-  if (hasTsconfigPathAlias(cwd)) {
-    // Convert src/server/paykit.ts → @/server/paykit
-    const srcRelative = path.relative(path.join(cwd, "src"), toFile);
-    if (!srcRelative.startsWith("..")) {
-      return "@/" + srcRelative.replace(/\.tsx?$/, "");
+function hasDependency(
+  pkg: { dependencies?: Record<string, string>; devDependencies?: Record<string, string> },
+  name: string,
+): boolean {
+  return Boolean(pkg.dependencies?.[name] || pkg.devDependencies?.[name]);
+}
+
+export function detectFramework(cwd: string): Framework | null {
+  const pkg = readPackageJson(cwd);
+
+  // Strategy 1: check package.json dependencies
+  if (pkg) {
+    for (const framework of FRAMEWORKS) {
+      if (hasDependency(pkg, framework.dependency)) {
+        return framework;
+      }
     }
   }
 
-  // Compute relative path
-  const fromDir = path.dirname(fromFile);
-  let relative = path.relative(fromDir, toFile).replace(/\.tsx?$/, "");
-  if (!relative.startsWith(".")) {
-    relative = "./" + relative;
+  // Strategy 2: check for framework config files
+  let cwdFiles: string[];
+  try {
+    cwdFiles = fs.readdirSync(cwd);
+  } catch {
+    return null;
   }
-  return relative;
+
+  for (const framework of FRAMEWORKS) {
+    if (!framework.configPaths?.length) continue;
+
+    for (const configPath of framework.configPaths) {
+      if (cwdFiles.includes(configPath)) {
+        return framework;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function detectNextJsRouterPath(cwd: string): string {
+  const rootFiles = safeReaddir(cwd);
+  const hasAppDir = rootFiles.includes("app");
+  const hasPagesDir = rootFiles.includes("pages");
+  const hasSrcDir = rootFiles.includes("src");
+
+  if (hasSrcDir) {
+    const srcFiles = safeReaddir(path.join(cwd, "src"));
+    if (srcFiles.includes("pages")) return "src/pages/api/paykit/[...slug].ts";
+    if (srcFiles.includes("app")) return "src/app/api/paykit/[...slug]/route.ts";
+  }
+
+  if (hasPagesDir) return "pages/api/paykit/[...slug].ts";
+  if (hasAppDir) return "app/api/paykit/[...slug]/route.ts";
+
+  return "src/app/api/paykit/[...slug]/route.ts";
+}
+
+function safeReaddir(dir: string): string[] {
+  try {
+    return fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+function parseTsconfig(cwd: string): {
+  paths?: Record<string, string[]>;
+  baseUrl?: string;
+} | null {
+  for (const name of ["tsconfig.json", "jsconfig.json"]) {
+    const configPath = path.join(cwd, name);
+    if (!fs.existsSync(configPath)) continue;
+
+    try {
+      const raw = fs.readFileSync(configPath, "utf-8");
+      const stripped = raw.replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, "");
+      const config = JSON.parse(stripped) as {
+        compilerOptions?: { paths?: Record<string, string[]>; baseUrl?: string };
+      };
+      return {
+        paths: config.compilerOptions?.paths,
+        baseUrl: config.compilerOptions?.baseUrl,
+      };
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+export function resolveImportPath(
+  fromFile: string,
+  toFile: string,
+  cwd: string,
+  framework?: Framework,
+): string {
+  const absoluteTo = path.resolve(cwd, toFile);
+  const absoluteFrom = path.resolve(cwd, fromFile);
+  const fromDir = path.dirname(absoluteFrom);
+
+  // SvelteKit uses $lib alias
+  if (framework?.id === "sveltekit") {
+    const relativeTo = path.relative(cwd, absoluteTo).replace(/\\/g, "/");
+    if (relativeTo.startsWith("src/lib/")) {
+      const after = relativeTo.slice("src/lib/".length).replace(/\.(ts|js|tsx|jsx)$/, "");
+      return after ? `$lib/${after}` : "$lib/paykit";
+    }
+  }
+
+  // Hono and other backend frameworks: always use relative imports
+  if (framework?.id === "hono") {
+    let rel = path.relative(fromDir, absoluteTo).replace(/\.(ts|js|tsx|jsx)$/, "");
+    if (!rel.startsWith(".")) rel = `./${rel}`;
+    return rel.replace(/\\/g, "/");
+  }
+
+  // Try tsconfig path aliases
+  const tsconfig = parseTsconfig(cwd);
+  if (tsconfig?.paths) {
+    for (const [alias, targets] of Object.entries(tsconfig.paths)) {
+      if (!alias.endsWith("/*") || !Array.isArray(targets) || targets.length === 0) continue;
+
+      const target = targets[0]!;
+      if (!target.endsWith("/*")) continue;
+
+      const aliasPrefix = alias.slice(0, -2);
+      let basePath = target.slice(0, -2);
+
+      if (tsconfig.baseUrl && tsconfig.baseUrl !== ".") {
+        basePath = path.join(tsconfig.baseUrl, basePath);
+      }
+
+      const normalizedBase = path.normalize(basePath).replace(/\\/g, "/");
+      const relativeTo = path.relative(cwd, absoluteTo).replace(/\\/g, "/");
+
+      // Base path is root (. or empty)
+      if (normalizedBase === "." || normalizedBase === "" || normalizedBase === "./") {
+        const withoutExt = relativeTo.replace(/\.(ts|js|tsx|jsx)$/, "");
+        return `${aliasPrefix}/${withoutExt}`;
+      }
+
+      // Check if target file is within the alias base path
+      if (relativeTo.startsWith(normalizedBase + "/") || relativeTo === normalizedBase) {
+        const after =
+          relativeTo === normalizedBase ? "" : relativeTo.slice(normalizedBase.length + 1);
+        const withoutExt = after.replace(/\.(ts|js|tsx|jsx)$/, "");
+        return withoutExt ? `${aliasPrefix}/${withoutExt}` : aliasPrefix;
+      }
+    }
+  }
+
+  // Fallback: relative path
+  let relative = path.relative(fromDir, absoluteTo).replace(/\.(ts|js|tsx|jsx)$/, "");
+  if (!relative.startsWith(".")) relative = `./${relative}`;
+  return relative.replace(/\\/g, "/");
 }
 
 export function defaultConfigPath(cwd: string): string {
-  if (fs.existsSync(path.join(cwd, "src", "server"))) return "src/server/paykit.ts";
-  if (fs.existsSync(path.join(cwd, "src", "lib"))) return "src/lib/paykit.ts";
-  if (fs.existsSync(path.join(cwd, "src"))) return "src/paykit.ts";
+  if (fs.existsSync(path.join(cwd, "src"))) return "src/lib/paykit.ts";
   return "paykit.ts";
 }
 
-export function defaultRoutePath(cwd: string): string {
-  if (fs.existsSync(path.join(cwd, "src", "app"))) {
-    return "src/app/paykit/api/[...slug]/route.ts";
-  }
-  if (fs.existsSync(path.join(cwd, "app"))) {
-    return "app/paykit/api/[...slug]/route.ts";
-  }
-  return "src/app/paykit/api/[...slug]/route.ts";
+export function defaultClientPath(cwd: string): string {
+  if (fs.existsSync(path.join(cwd, "src", "lib"))) return "src/lib/paykit-client.ts";
+  if (fs.existsSync(path.join(cwd, "src"))) return "src/paykit-client.ts";
+  return "paykit-client.ts";
 }

--- a/packages/paykit/src/cli/utils/env.ts
+++ b/packages/paykit/src/cli/utils/env.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export function getEnvFiles(cwd: string): string[] {
+  try {
+    const files = fs.readdirSync(cwd);
+    return files
+      .filter((file) => file.startsWith(".env") && file !== ".env.example")
+      .map((file) => path.join(cwd, file));
+  } catch {
+    return [];
+  }
+}
+
+export function parseEnvFiles(envFiles: string[]): Map<string, string[]> {
+  const result = new Map<string, string[]>();
+  for (const file of envFiles) {
+    const content = fs.readFileSync(file, "utf-8");
+    const existingVars = content
+      .split("\n")
+      .filter((line) => line.trim())
+      .map((x) => x.split("=")[0])
+      .filter((x): x is string => Boolean(x?.trim()))
+      .filter((x) => !x.includes(" "))
+      .filter((x) => !x.startsWith("#"));
+    result.set(file, existingVars);
+  }
+  return result;
+}
+
+export function getMissingEnvVars(
+  envFiles: Map<string, string[]>,
+  vars: string[],
+): { file: string; missing: string[] }[] {
+  const result: { file: string; missing: string[] }[] = [];
+  for (const [file, existingVars] of envFiles) {
+    const missing = vars.filter((v) => !existingVars.includes(v));
+    if (missing.length > 0) {
+      result.push({ file, missing });
+    }
+  }
+  return result;
+}
+
+export function updateEnvFiles(envFiles: string[], lines: string[]): void {
+  for (const file of envFiles) {
+    let content = fs.readFileSync(file, "utf-8");
+    if (content.length > 0 && !content.endsWith("\n")) {
+      content += "\n";
+    }
+    content += lines.join("\n") + "\n";
+    fs.writeFileSync(file, content);
+  }
+}
+
+export function createEnvFile(cwd: string, lines: string[]): void {
+  const envFile = path.join(cwd, ".env");
+  fs.writeFileSync(envFile, lines.join("\n") + "\n");
+}

--- a/packages/paykit/src/types/schema.ts
+++ b/packages/paykit/src/types/schema.ts
@@ -147,21 +147,13 @@ export interface NormalizedSchema {
   planMap: ReadonlyMap<string, NormalizedPlan>;
 }
 
-export type PayKitPlansModule = readonly PayKitPlan[] | Record<string, unknown>;
+export type PayKitPlansModule = readonly PayKitPlan[];
 
 export type PlanIdFromPlans<TPlans> = TPlans extends readonly (infer TItem)[]
   ? TItem extends PayKitPlan<PayKitPlanConfig<infer TId>>
     ? TId
     : never
-  : TPlans extends Record<PropertyKey, unknown>
-    ? TPlans[keyof TPlans] extends infer TValue
-      ? TValue extends { id: infer TId extends string }
-        ? TValue extends PayKitPlan
-          ? TId
-          : never
-        : never
-      : never
-    : never;
+  : never;
 
 type ExtractFeatureIds<TPlan> = TPlan extends {
   includes: readonly (infer TInclude)[];
@@ -173,9 +165,7 @@ type ExtractFeatureIds<TPlan> = TPlan extends {
 
 export type FeatureIdFromPlans<TPlans> = TPlans extends readonly (infer TItem)[]
   ? ExtractFeatureIds<TItem>
-  : TPlans extends Record<PropertyKey, unknown>
-    ? ExtractFeatureIds<TPlans[keyof TPlans]>
-    : never;
+  : never;
 
 function defineHiddenBrand(target: object, symbol: symbol): void {
   Object.defineProperty(target, symbol, {
@@ -355,9 +345,7 @@ export function normalizeSchema(plans: PayKitPlansModule | undefined): Normalize
     };
   }
 
-  const exportedPlans = Array.isArray(plans)
-    ? plans.filter(isPayKitPlan)
-    : Object.values(plans).filter(isPayKitPlan);
+  const exportedPlans = plans.filter(isPayKitPlan);
   const features = new Map<string, NormalizedFeature>();
   const defaultPlansByGroup = new Map<string, string>();
   const plansById = new Map<string, NormalizedPlan>();

--- a/packages/paykit/src/types/schema.ts
+++ b/packages/paykit/src/types/schema.ts
@@ -345,7 +345,12 @@ export function normalizeSchema(plans: PayKitPlansModule | undefined): Normalize
     };
   }
 
-  const exportedPlans = plans.filter(isPayKitPlan);
+  const exportedPlans = plans.map((planValue, index) => {
+    if (!isPayKitPlan(planValue)) {
+      throw new Error(`Invalid plan at index ${index}. Expected values returned by plan(...).`);
+    }
+    return planValue;
+  });
   const features = new Map<string, NormalizedFeature>();
   const defaultPlansByGroup = new Map<string, string>();
   const plansById = new Map<string, NormalizedPlan>();

--- a/packages/paykit/src/types/schema.ts
+++ b/packages/paykit/src/types/schema.ts
@@ -345,6 +345,10 @@ export function normalizeSchema(plans: PayKitPlansModule | undefined): Normalize
     };
   }
 
+  if (!Array.isArray(plans)) {
+    throw new Error("Invalid `plans` export. Expected an array of values returned by plan(...).");
+  }
+
   const exportedPlans = plans.map((planValue, index) => {
     if (!isPayKitPlan(planValue)) {
       throw new Error(`Invalid plan at index ${index}. Expected values returned by plan(...).`);


### PR DESCRIPTION
## Summary
- Overhaul `paykitjs init` CLI with 13 framework auto-detection and generation (Next.js, Tanstack Start, Nuxt, SvelteKit, Remix, Astro, Solid Start, React Router, Hono, Express, Fastify, Elysia, Nitro)
- Smart env var handling — parse existing `.env` files, only add missing vars
- Framework-specific route handler and client generation with tsconfig alias support
- Skip prompts for existing files on re-run, show "already initialized" message
- Add `--defaults/-y` flag for non-interactive setup
- Plans as array only — remove `Record<string, unknown>` from `PayKitPlansModule`
- Use connection string instead of `pg` Pool in generated config
- Add `identify` function only when client is generated
- Async dependency install with animated spinner and error reporting
- Package manager aware commands throughout (exec, dlx, install)
- Validate framework detection and package.json before prompting

## Test plan
- [ ] Run `paykitjs init` in a Next.js project (App Router + Pages Router)
- [ ] Run `paykitjs init` in a Tanstack Start project
- [ ] Run `paykitjs init --defaults` for non-interactive setup
- [ ] Run `paykitjs init` twice to verify re-run skips existing files
- [ ] Run `paykitjs init` outside a project to verify error messages
- [ ] Run `paykitjs init` in monorepo root to verify framework detection error
- [ ] Verify generated config uses connection string, plans as array, correct imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now auto-detects framework/router, skips existing generated files, and adds a --defaults flag to run non-interactively.

* **Bug Fixes**
  * Improved dependency-install error reporting and clearer final messages when no files are created.

* **Chores**
  * Revised .env handling to update/create appropriate env files only.
  * Updated generated config/client resolution and plan data (pro plan price is now 29).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->