### PR TITLE
fix(landing): instant feedback on copy markdown button

### DIFF
--- a/landing/src/components/docs/copy-markdown-button.tsx
+++ b/landing/src/components/docs/copy-markdown-button.tsx
@@ -2,18 +2,24 @@
 
 import { Check, Copy } from "lucide-react";
 import { useCallback, useState } from "react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 
 export function CopyMarkdownButton({ markdownUrl }: { markdownUrl: string }) {
   const [copied, setCopied] = useState(false);
 
-  const onClick = useCallback(async () => {
-    const res = await fetch(markdownUrl);
-    const text = await res.text();
-    await navigator.clipboard.writeText(text);
+  const onClick = useCallback(() => {
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+
+    fetch(markdownUrl)
+      .then((res) => res.text())
+      .then((text) => navigator.clipboard.writeText(text))
+      .catch(() => {
+        toast.error("Failed to copy markdown");
+        setCopied(false);
+      });
   }, [markdownUrl]);
 
   return (

--- a/landing/src/components/docs/copy-markdown-button.tsx
+++ b/landing/src/components/docs/copy-markdown-button.tsx
@@ -13,8 +13,11 @@ export function CopyMarkdownButton({ markdownUrl }: { markdownUrl: string }) {
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
 
-    fetch(markdownUrl)
-      .then((res) => res.text())
+    void fetch(markdownUrl)
+      .then((res) => {
+        if (!res.ok) throw new Error("fetch failed");
+        return res.text();
+      })
       .then((text) => navigator.clipboard.writeText(text))
       .catch(() => {
         toast.error("Failed to copy markdown");


### PR DESCRIPTION
## Summary
- Show "Copied" state instantly on click instead of waiting for the markdown fetch to complete
- If the fetch or clipboard write fails, revert the state and show an error toast via sonner

## Test plan
- [ ] Click "Copy Markdown" on a docs page — should show "Copied" immediately
- [ ] Paste content — should contain the correct markdown
- [ ] Simulate network failure — should show error toast and revert button state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for the copy markdown button: users now see an error toast if fetching or copying fails.
  * Improved copy feedback: the success state is applied immediately and reliably resets after 2 seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->