### PR TITLE
feat(paykit): resolve products by hash instead of latest version

### DIFF
--- a/landing/content/docs/concepts/cli.mdx
+++ b/landing/content/docs/concepts/cli.mdx
@@ -28,6 +28,20 @@ The command you'll run most often. It does two things:
 
 Run it on initial setup and again whenever you change your plan configuration.
 
+### How versioning works
+
+When you change a plan and push, PayKit creates a new version of that plan. Old versions are never modified or deleted. This means running instances of your app keep working on their matching version while new code picks up the new one.
+
+### Production usage
+
+Run `push` before your app starts or builds, as part of your deploy pipeline. This way the updated product versions are ready in the database by the time your new code goes live.
+
+```bash
+paykitjs push -y && next build
+```
+
+This is similar to how you'd run database migrations on deploy. The `-y` flag skips the confirmation prompt.
+
 ## `paykitjs status`
 
 <PackageRun command="paykitjs status" />

--- a/landing/content/docs/concepts/database.mdx
+++ b/landing/content/docs/concepts/database.mdx
@@ -59,4 +59,4 @@ PayKit keeps two sources of truth in sync:
 
 **From webhooks** (provider to database): Subscriptions, invoices, payment methods, and customer-provider ID mappings are synced automatically when provider events arrive.
 
-**From your config** (code to database): Plans, products, and features are synced from your `createPayKit` configuration when you run `paykitjs push`.
+**From your config** (code to database): Plans, products, and features are synced from your `createPayKit` configuration when you run `paykitjs push`. Each time you change a plan and push, a new version is created. Previous versions are kept so running instances can continue serving existing subscriptions.

--- a/landing/content/docs/get-started/installation.mdx
+++ b/landing/content/docs/get-started/installation.mdx
@@ -216,8 +216,9 @@ PayKit includes a CLI tool to keep your database in sync with your configuration
 
 <Callout>
   This applies database migrations and syncs your plan definitions to provider's
-  products. 
+  products.
 <br/>Run it once on setup, and every time after you change your products configuration.
+<br/>For production deployments, see the [CLI reference](/docs/concepts/cli#production-usage).
 </Callout>
 
 </Step>

--- a/packages/paykit/src/core/errors.ts
+++ b/packages/paykit/src/core/errors.ts
@@ -7,8 +7,8 @@ export const PAYKIT_ERROR_CODES = defineErrorCodes({
   CUSTOMER_CREATE_FAILED: "Failed to create customer",
   CUSTOMER_UPDATE_FAILED: "Failed to update customer",
 
-  PLAN_NOT_FOUND: "Plan not found. Run: paykitjs push",
-  PLAN_NOT_SYNCED: "Plan is not synced with provider. Run: paykitjs push",
+  PLAN_NOT_FOUND: "Plan not found",
+  PLAN_NOT_SYNCED: "Plan is not synced with provider",
   PLAN_SYNC_FAILED: "Failed to sync plan",
 
   SUBSCRIPTION_CREATE_FAILED: "Failed to create subscription",

--- a/packages/paykit/src/customer/customer.service.ts
+++ b/packages/paykit/src/customer/customer.service.ts
@@ -11,7 +11,7 @@ import {
   product,
   subscription,
 } from "../database/schema";
-import { getLatestProduct } from "../product/product.service";
+import { getProductByHash } from "../product/product.service";
 import type { ProviderCustomer, ProviderCustomerMap } from "../providers/provider";
 import {
   getActiveSubscriptionInGroup,
@@ -159,7 +159,7 @@ export async function ensureDefaultPlansForCustomer(
       continue;
     }
 
-    const storedPlan = await getLatestProduct(ctx.database, defaultPlan.id);
+    const storedPlan = await getProductByHash(ctx.database, defaultPlan.id, defaultPlan.hash);
     if (!storedPlan) {
       continue;
     }

--- a/packages/paykit/src/customer/customer.service.ts
+++ b/packages/paykit/src/customer/customer.service.ts
@@ -27,6 +27,12 @@ import type {
   ListCustomersResult,
 } from "./customer.types";
 
+function stableStringify(value: Record<string, string> | null | undefined): string {
+  if (value == null) return "null";
+  const sorted = Object.keys(value).sort();
+  return JSON.stringify(value, sorted);
+}
+
 function appendEntitlement(
   entitlements: Record<string, CustomerEntitlement>,
   row: {
@@ -356,8 +362,8 @@ function providerCustomerNeedsSync(
 ): boolean {
   if ((existing.syncedEmail ?? null) !== (customer.email ?? null)) return true;
   if ((existing.syncedName ?? null) !== (customer.name ?? null)) return true;
-  const existingMeta = JSON.stringify(existing.syncedMetadata ?? null);
-  const currentMeta = JSON.stringify(customer.metadata ?? null);
+  const existingMeta = stableStringify(existing.syncedMetadata);
+  const currentMeta = stableStringify(customer.metadata);
   return existingMeta !== currentMeta;
 }
 

--- a/packages/paykit/src/product/product.service.ts
+++ b/packages/paykit/src/product/product.service.ts
@@ -90,6 +90,18 @@ export async function getLatestProduct(
   return result ?? null;
 }
 
+export async function getProductByHash(
+  database: PayKitDatabase,
+  id: string,
+  hash: string,
+): Promise<StoredProduct | null> {
+  const result = await database.query.product.findFirst({
+    where: and(eq(product.id, id), eq(product.hash, hash)),
+  });
+
+  return result ?? null;
+}
+
 export async function getLatestProductSnapshot(
   database: PayKitDatabase,
   id: string,

--- a/packages/paykit/src/product/product.service.ts
+++ b/packages/paykit/src/product/product.service.ts
@@ -103,6 +103,17 @@ export async function getProductByHash(
   return result ?? null;
 }
 
+export async function getProductByInternalId(
+  database: PayKitDatabase,
+  internalId: string,
+): Promise<StoredProduct | null> {
+  const result = await database.query.product.findFirst({
+    where: eq(product.internalId, internalId),
+  });
+
+  return result ?? null;
+}
+
 export async function getLatestProductSnapshot(
   database: PayKitDatabase,
   id: string,

--- a/packages/paykit/src/product/product.service.ts
+++ b/packages/paykit/src/product/product.service.ts
@@ -97,6 +97,7 @@ export async function getProductByHash(
 ): Promise<StoredProduct | null> {
   const result = await database.query.product.findFirst({
     where: and(eq(product.id, id), eq(product.hash, hash)),
+    orderBy: (p, { desc }) => [desc(p.version)],
   });
 
   return result ?? null;

--- a/packages/paykit/src/subscription/subscription.service.ts
+++ b/packages/paykit/src/subscription/subscription.service.ts
@@ -14,6 +14,7 @@ import { getDefaultPaymentMethod } from "../payment-method/payment-method.servic
 import {
   getDefaultProductInGroup,
   getProductByHash,
+  getProductByInternalId,
   getProductByProviderPriceId,
   getProductFeatures,
   withProviderInfo,
@@ -96,18 +97,12 @@ async function resolveStoredPlanFeatures(
 export async function loadSubscribeContext(ctx: PayKitContext, input: SubscribeInput) {
   const providerId = ctx.provider.id;
   const normalizedPlan = ctx.plans.planMap.get(input.planId);
-  const resolvedHash = input.planHash ?? normalizedPlan?.hash;
-  const matchingProduct = resolvedHash
-    ? await getProductByHash(ctx.database, input.planId, resolvedHash)
-    : null;
+  const matchingProduct = input.productInternalId
+    ? await getProductByInternalId(ctx.database, input.productInternalId)
+    : normalizedPlan
+      ? await getProductByHash(ctx.database, input.planId, normalizedPlan.hash)
+      : null;
   const storedPlan = matchingProduct ? withProviderInfo(matchingProduct, providerId) : null;
-
-  if (resolvedHash && !storedPlan) {
-    ctx.logger.error(
-      { planId: input.planId, hash: resolvedHash },
-      `No synced version of plan "${input.planId}" matches hash "${resolvedHash}". Run \`paykitjs push\` to sync.`,
-    );
-  }
 
   if (!storedPlan) {
     throw PayKitError.from(
@@ -314,7 +309,7 @@ export async function prepareSubscribeCheckoutCompleted(
 
   const customerId = event.payload.metadata?.paykit_customer_id;
   const planId = event.payload.metadata?.paykit_plan_id;
-  const planHash = event.payload.metadata?.paykit_plan_hash;
+  const productInternalId = event.payload.metadata?.paykit_product_internal_id;
   if (!customerId || !planId) {
     throw PayKitError.from(
       "BAD_REQUEST",
@@ -334,8 +329,8 @@ export async function prepareSubscribeCheckoutCompleted(
 
   const subCtx = await loadSubscribeContext(ctx, {
     customerId,
-    planHash: planHash ?? undefined,
     planId,
+    productInternalId: productInternalId ?? undefined,
     successUrl: "https://paykit.invalid/checkout",
   });
   if (subCtx.storedPlan.providerPriceId !== checkoutSubscription.providerPriceId) {
@@ -1061,8 +1056,8 @@ async function createCheckoutSubscribe(
     metadata: {
       paykit_customer_id: subCtx.customerId,
       paykit_intent: "subscribe",
-      paykit_plan_hash: subCtx.storedPlan.hash!,
       paykit_plan_id: subCtx.storedPlan.id,
+      paykit_product_internal_id: subCtx.storedPlan.internalId,
     },
     providerCustomerId: subCtx.providerCustomerId,
     providerPriceId: subCtx.storedPlan.providerPriceId!,

--- a/packages/paykit/src/subscription/subscription.service.ts
+++ b/packages/paykit/src/subscription/subscription.service.ts
@@ -13,7 +13,7 @@ import { upsertInvoiceRecord } from "../invoice/invoice.service";
 import { getDefaultPaymentMethod } from "../payment-method/payment-method.service";
 import {
   getDefaultProductInGroup,
-  getLatestProduct,
+  getProductByHash,
   getProductByProviderPriceId,
   withProviderInfo,
 } from "../product/product.service";
@@ -73,26 +73,23 @@ export async function subscribeToPlan(
 export async function loadSubscribeContext(ctx: PayKitContext, input: SubscribeInput) {
   const providerId = ctx.provider.id;
   const normalizedPlan = ctx.plans.planMap.get(input.planId);
-  const latestProduct = await getLatestProduct(ctx.database, input.planId);
-  const storedPlan = latestProduct ? withProviderInfo(latestProduct, providerId) : null;
+  const matchingProduct = normalizedPlan
+    ? await getProductByHash(ctx.database, input.planId, normalizedPlan.hash)
+    : null;
+  const storedPlan = matchingProduct ? withProviderInfo(matchingProduct, providerId) : null;
+
+  if (normalizedPlan && !storedPlan) {
+    ctx.logger.error(
+      { planId: input.planId, hash: normalizedPlan.hash },
+      `No synced version of plan "${input.planId}" matches the current schema. Run \`paykitjs push\` to sync.`,
+    );
+  }
 
   if (!normalizedPlan || !storedPlan) {
     throw PayKitError.from(
       "NOT_FOUND",
       PAYKIT_ERROR_CODES.PLAN_NOT_FOUND,
       `Plan "${input.planId}" not found`,
-    );
-  }
-
-  if (storedPlan.hash !== normalizedPlan.hash) {
-    ctx.logger.error(
-      { planId: input.planId },
-      `Plan "${input.planId}" is out of sync. Run \`paykitjs push\` to update.`,
-    );
-    throw PayKitError.from(
-      "INTERNAL_SERVER_ERROR",
-      PAYKIT_ERROR_CODES.PLAN_NOT_SYNCED,
-      `Plan "${input.planId}" schema has changed since last sync. Run \`paykitjs push\` to update.`,
     );
   }
 

--- a/packages/paykit/src/subscription/subscription.service.ts
+++ b/packages/paykit/src/subscription/subscription.service.ts
@@ -8,13 +8,14 @@ import {
   upsertProviderCustomer,
 } from "../customer/customer.service";
 import type { PayKitDatabase } from "../database";
-import { entitlement, product, subscription } from "../database/schema";
+import { entitlement, feature, product, subscription } from "../database/schema";
 import { upsertInvoiceRecord } from "../invoice/invoice.service";
 import { getDefaultPaymentMethod } from "../payment-method/payment-method.service";
 import {
   getDefaultProductInGroup,
   getProductByHash,
   getProductByProviderPriceId,
+  getProductFeatures,
   withProviderInfo,
 } from "../product/product.service";
 import type { ProviderRequiredAction, ProviderSubscription } from "../providers/provider";
@@ -70,22 +71,45 @@ export async function subscribeToPlan(
   });
 }
 
+async function resolveStoredPlanFeatures(
+  database: PayKitDatabase,
+  productInternalId: string,
+): Promise<readonly NormalizedPlanFeature[]> {
+  const stored = await getProductFeatures(database, productInternalId);
+  const featureIds = stored.map((f) => f.featureId);
+  const features =
+    featureIds.length > 0
+      ? await database.query.feature.findMany({
+          where: inArray(feature.id, featureIds),
+        })
+      : [];
+  const featureTypeMap = new Map(features.map((f) => [f.id, f.type]));
+  return stored.map((f) => ({
+    config: f.config,
+    id: f.featureId,
+    limit: f.limit,
+    resetInterval: f.resetInterval as NormalizedPlanFeature["resetInterval"],
+    type: (featureTypeMap.get(f.featureId) ?? "metered") as NormalizedPlanFeature["type"],
+  }));
+}
+
 export async function loadSubscribeContext(ctx: PayKitContext, input: SubscribeInput) {
   const providerId = ctx.provider.id;
   const normalizedPlan = ctx.plans.planMap.get(input.planId);
-  const matchingProduct = normalizedPlan
-    ? await getProductByHash(ctx.database, input.planId, normalizedPlan.hash)
+  const resolvedHash = input.planHash ?? normalizedPlan?.hash;
+  const matchingProduct = resolvedHash
+    ? await getProductByHash(ctx.database, input.planId, resolvedHash)
     : null;
   const storedPlan = matchingProduct ? withProviderInfo(matchingProduct, providerId) : null;
 
-  if (normalizedPlan && !storedPlan) {
+  if (resolvedHash && !storedPlan) {
     ctx.logger.error(
-      { planId: input.planId, hash: normalizedPlan.hash },
-      `No synced version of plan "${input.planId}" matches the current schema. Run \`paykitjs push\` to sync.`,
+      { planId: input.planId, hash: resolvedHash },
+      `No synced version of plan "${input.planId}" matches hash "${resolvedHash}". Run \`paykitjs push\` to sync.`,
     );
   }
 
-  if (!normalizedPlan || !storedPlan) {
+  if (!storedPlan) {
     throw PayKitError.from(
       "NOT_FOUND",
       PAYKIT_ERROR_CODES.PLAN_NOT_FOUND,
@@ -134,6 +158,10 @@ export async function loadSubscribeContext(ctx: PayKitContext, input: SubscribeI
     hasProviderSubscription(activeSubscription) &&
     targetAmount > activeAmount;
 
+  const planFeatures = normalizedPlan
+    ? normalizedPlan.includes
+    : await resolveStoredPlanFeatures(ctx.database, storedPlan.internalId);
+
   return {
     activeSubscription,
     cancelUrl: input.cancelUrl,
@@ -142,6 +170,7 @@ export async function loadSubscribeContext(ctx: PayKitContext, input: SubscribeI
     isPaidTarget,
     isUpgrade,
     normalizedPlan,
+    planFeatures,
     providerCustomerId,
     providerId,
     scheduledSubscriptions,
@@ -285,6 +314,7 @@ export async function prepareSubscribeCheckoutCompleted(
 
   const customerId = event.payload.metadata?.paykit_customer_id;
   const planId = event.payload.metadata?.paykit_plan_id;
+  const planHash = event.payload.metadata?.paykit_plan_hash;
   if (!customerId || !planId) {
     throw PayKitError.from(
       "BAD_REQUEST",
@@ -304,6 +334,7 @@ export async function prepareSubscribeCheckoutCompleted(
 
   const subCtx = await loadSubscribeContext(ctx, {
     customerId,
+    planHash: planHash ?? undefined,
     planId,
     successUrl: "https://paykit.invalid/checkout",
   });
@@ -1030,6 +1061,7 @@ async function createCheckoutSubscribe(
     metadata: {
       paykit_customer_id: subCtx.customerId,
       paykit_intent: "subscribe",
+      paykit_plan_hash: subCtx.storedPlan.hash!,
       paykit_plan_id: subCtx.storedPlan.id,
     },
     providerCustomerId: subCtx.providerCustomerId,
@@ -1050,7 +1082,7 @@ async function insertLocalTargetSubscription(
 ): Promise<void> {
   await insertSubscriptionRecord(database, {
     customerId: subCtx.customerId,
-    planFeatures: subCtx.normalizedPlan.includes,
+    planFeatures: subCtx.planFeatures,
     productInternalId: subCtx.storedPlan.internalId,
     providerId: subCtx.providerId,
     startedAt: input.startedAt,
@@ -1095,7 +1127,7 @@ async function upsertProviderBackedTargetSubscription(
       currentPeriodEndAt: input.subscription.currentPeriodEndAt ?? null,
       currentPeriodStartAt: input.subscription.currentPeriodStartAt ?? null,
       customerId: subCtx.customerId,
-      planFeatures: subCtx.normalizedPlan.includes,
+      planFeatures: subCtx.planFeatures,
       productInternalId: subCtx.storedPlan.internalId,
       providerId: subCtx.providerId,
       providerData,

--- a/packages/paykit/src/subscription/subscription.types.ts
+++ b/packages/paykit/src/subscription/subscription.types.ts
@@ -14,7 +14,7 @@ export type SubscribeBody = z.infer<typeof subscribeBodySchema>;
 
 export type SubscribeInput = SubscribeBody & {
   customerId: string;
-  planHash?: string;
+  productInternalId?: string;
 };
 
 export interface SubscribeResult {

--- a/packages/paykit/src/subscription/subscription.types.ts
+++ b/packages/paykit/src/subscription/subscription.types.ts
@@ -14,6 +14,7 @@ export type SubscribeBody = z.infer<typeof subscribeBodySchema>;
 
 export type SubscribeInput = SubscribeBody & {
   customerId: string;
+  planHash?: string;
 };
 
 export interface SubscribeResult {


### PR DESCRIPTION
## Summary
- Subscribe and default-plan flows now look up the product version matching the current schema hash instead of always fetching the latest version
- Eliminates the failure window between `push` and deploy where a hash mismatch would reject subscriptions
- Adds docs on plan versioning and recommended production `push` usage

## Test plan
- [x] Typecheck passes
- [x] Customer service tests pass
- [ ] Verify subscribe flow works when pushed version != latest (e.g. push v2, old code still expects v1)
- [ ] Verify subscribe throws when plan was never pushed

Closes #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI plan-versioning behavior and added production deploy guidance and CLI reference.
  * Improved docs on product/plan sync and push-before-build workflow.

* **Bug Fixes**
  * More reliable plan/version resolution during subscription and checkout flows so subscribers receive the correct plan version.
  * Shortened error messages and more robust metadata comparison for provider syncs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->