### PR TITLE
feat(paykit): custom currencies

### DIFF
--- a/landing/content/docs/concepts/plans-and-features.mdx
+++ b/landing/content/docs/concepts/plans-and-features.mdx
@@ -116,14 +116,14 @@ export const free = plan({
 
 ## Pricing
 
-Plans without a `price` are free. Paid plans take an `amount` in dollars and an `interval`.
+Plans without a `price` are free. Paid plans take an `amount` in major currency units and an `interval`.
 
 ```ts
 price: { amount: 19, interval: "month" }
 ```
 
 - `interval` can be `month` or `year`
-- `amount` is in dollars, max $999,999.99
+- `amount` is in the provider's default currency, with the maximum being the provider's maximum for that currency, usually $999,999.99.
 
 ## Passing plans to PayKit
 

--- a/landing/content/docs/get-started/installation.mdx
+++ b/landing/content/docs/get-started/installation.mdx
@@ -10,8 +10,6 @@ description: Install PayKit, configure your billing instance, and mount the rout
 
 Let's start by adding PayKit to your project:
 
-
-
 <PackageInstall package="paykitjs" />
 
 <Callout type="info">
@@ -24,7 +22,7 @@ Let's start by adding PayKit to your project:
 <Step>
 ## Create the PayKit instance
 
-Create a file named `paykit.ts` anywhere in your app. 
+Create a file named `paykit.ts` anywhere in your app.
 
 Usually you would put it somewhere in `src/`, `src/lib/`.
 
@@ -58,6 +56,7 @@ export const paykit = createPayKit({
   provider: stripe({ // [!code highlight]
     secretKey: process.env.STRIPE_SECRET_KEY!, // [!code highlight]
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET!,// [!code highlight]
+    currency: "gbp", // optional, defaults to "usd" // [!code highlight]
   }),// [!code highlight]
 });
 ```
@@ -156,10 +155,11 @@ export const paykit = createPayKit({
 <Step>
 ## Define your products
 
-Optionally. PayKit provides a code-first way to create your plans, and a very useful usage billing with `track()` and `report()` out of the box. 
+Optionally. PayKit provides a code-first way to create your plans, and a very useful usage billing with `track()` and `report()` out of the box.
 
 By defining you products in code don't have to touch Stripe's dashboard at all. It automatically syncs your pricing with your provider, and you unlock a full type-safety with inferred ID types!
 
+`price.amount` is in major currency units for your provider's default currency. With Stripe that defaults to `usd`, and you can override it with `provider: stripe({ currency: "gbp" })`.
 
 ```ts title="plans.ts"
 import { feature, plan } from "paykitjs";
@@ -200,7 +200,6 @@ export const paykit = createPayKit({
 });
 ```
 
-
 <Callout type="info">
   This is an example setup for AI chat app. Read further on how to build your own billing config.
 </Callout>
@@ -216,7 +215,7 @@ PayKit includes a CLI tool to keep your database in sync with your configuration
 
 <Callout>
   This applies database migrations and syncs your plan definitions to provider's
-  products. 
+  products.
 <br/>Run it once on setup, and every time after you change your products configuration.
 </Callout>
 

--- a/landing/content/docs/providers/stripe.mdx
+++ b/landing/content/docs/providers/stripe.mdx
@@ -22,9 +22,12 @@ export const paykit = createPayKit({
   provider: stripe({
     secretKey: process.env.STRIPE_SECRET_KEY!,
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET!,
+    currency: "gbp",
   }),
 });
 ```
+
+`currency` sets the default Stripe currency for synced prices and generated invoices. It defaults to `"usd"`.
 
 ## Environment variables
 

--- a/packages/stripe/src/__tests__/stripe.test.ts
+++ b/packages/stripe/src/__tests__/stripe.test.ts
@@ -4,6 +4,107 @@ import { describe, expect, it, vi } from "vitest";
 import { createStripeProvider, stripe } from "../stripe-provider";
 
 describe("providers/stripe", () => {
+  it("uses usd by default when syncing Stripe prices", async () => {
+    const createProduct = vi.fn().mockResolvedValue({ id: "prod_123" });
+    const createPrice = vi.fn().mockResolvedValue({ id: "price_123" });
+    const runtime = createStripeProvider(
+      {
+        prices: { create: createPrice },
+        products: {
+          create: createProduct,
+          update: vi.fn(),
+        },
+      } as never,
+      {
+        secretKey: "sk_test_123",
+        webhookSecret: "whsec_123",
+      },
+    );
+
+    await runtime.syncProduct({
+      id: "pro",
+      name: "Pro",
+      priceAmount: 1_900,
+      priceInterval: "month",
+    });
+
+    expect(createPrice).toHaveBeenCalledWith({
+      currency: "usd",
+      product: "prod_123",
+      recurring: { interval: "month" },
+      unit_amount: 1_900,
+    });
+  });
+
+  it("uses the configured currency for Stripe prices and invoices", async () => {
+    const createProduct = vi.fn().mockResolvedValue({ id: "prod_123" });
+    const createPrice = vi.fn().mockResolvedValue({ id: "price_123" });
+    const createInvoice = vi.fn().mockResolvedValue({ id: "in_123" });
+    const addLines = vi.fn().mockResolvedValue(undefined);
+    const finalizeInvoice = vi.fn().mockResolvedValue({
+      currency: "eur",
+      hosted_invoice_url: "https://example.com/invoices/in_123",
+      id: "in_123",
+      period_end: 1_700_000_000,
+      period_start: 1_699_913_600,
+      status: "open",
+      total: 500,
+    });
+    const runtime = createStripeProvider(
+      {
+        invoices: {
+          addLines,
+          create: createInvoice,
+          finalizeInvoice,
+        },
+        prices: { create: createPrice },
+        products: {
+          create: createProduct,
+          update: vi.fn(),
+        },
+      } as never,
+      {
+        currency: "EUR",
+        secretKey: "sk_test_123",
+        webhookSecret: "whsec_123",
+      },
+    );
+
+    await runtime.syncProduct({
+      id: "pro",
+      name: "Pro",
+      priceAmount: 1_900,
+      priceInterval: "month",
+    });
+
+    const invoice = await runtime.createInvoice({
+      lines: [{ amount: 500, description: "Setup fee" }],
+      providerCustomerId: "cus_123",
+    });
+
+    expect(createPrice).toHaveBeenCalledWith({
+      currency: "eur",
+      product: "prod_123",
+      recurring: { interval: "month" },
+      unit_amount: 1_900,
+    });
+    expect(createInvoice).toHaveBeenCalledWith({
+      auto_advance: true,
+      collection_method: "charge_automatically",
+      currency: "eur",
+      customer: "cus_123",
+    });
+    expect(invoice).toEqual({
+      currency: "eur",
+      hostedUrl: "https://example.com/invoices/in_123",
+      periodEndAt: new Date(1_700_000_000 * 1000),
+      periodStartAt: new Date(1_699_913_600 * 1000),
+      providerInvoiceId: "in_123",
+      status: "open",
+      totalAmount: 500,
+    });
+  });
+
   it("creates a test clock and stores its id on the provider customer", async () => {
     const createClock = vi.fn().mockResolvedValue({
       frozen_time: 1_700_000_000,

--- a/packages/stripe/src/stripe-provider.ts
+++ b/packages/stripe/src/stripe-provider.ts
@@ -22,6 +22,12 @@ export interface StripeOptions {
   apiVersion?: string;
   /** Enable Stripe Managed Payments (requires a preview API version). */
   managedPayments?: boolean;
+  /**
+   * The currency to use when creating prices and invoices. Default is USD ($).
+   *
+   * See {@link https://docs.stripe.com/currencies | Stripe documentation}.
+   */
+  currency?: string;
 }
 
 type StripeInvoiceWithExtras = StripeSdk.Invoice & {
@@ -517,7 +523,7 @@ function createDetachedPaymentMethodEvents(event: StripeSdk.Event): NormalizedWe
 }
 
 export function createStripeProvider(client: StripeSdk, options: StripeOptions): PaymentProvider {
-  const currency = "usd";
+  const currency = options.currency?.toLowerCase() ?? "usd";
 
   return {
     id: "stripe",

--- a/packages/stripe/src/stripe-provider.ts
+++ b/packages/stripe/src/stripe-provider.ts
@@ -523,7 +523,7 @@ function createDetachedPaymentMethodEvents(event: StripeSdk.Event): NormalizedWe
 }
 
 export function createStripeProvider(client: StripeSdk, options: StripeOptions): PaymentProvider {
-  const currency = options.currency?.toLowerCase() ?? "usd";
+  const currency = options.currency?.trim().toLowerCase() || "usd";
 
   return {
     id: "stripe",


### PR DESCRIPTION
Up until now, `usd` was the default currency and couldn't be changed. This PR allows passing in `currency: "gbp"` in the setup for the Stripe provider to change the default currency used when creating prices and invoices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional currency setting for Stripe integration (defaults to USD).

* **Documentation**
  * Clarified that price amounts are in the provider's currency units and updated installation/provider examples to show currency configuration.
  * Minor formatting and whitespace cleanups in docs.

* **Tests**
  * Added tests validating currency handling for price and invoice creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->