### PR TITLE
fix(landing): align home nav borders with content borders

### DIFF
--- a/landing/src/app/(marketing)/layout.tsx
+++ b/landing/src/app/(marketing)/layout.tsx
@@ -11,8 +11,8 @@ export default async function MarketingLayout({ children }: { children: ReactNod
   return (
     <CommandMenuProvider>
       <div className="dark bg-background text-foreground relative h-dvh overflow-x-hidden">
-        <NavigationBar stars={null} />
         <div className="absolute inset-0 overflow-x-hidden overflow-y-auto">
+          <NavigationBar stars={null} />
           <PageTransition>{children}</PageTransition>
         </div>
       </div>

--- a/landing/src/components/layout/navigation-bar.tsx
+++ b/landing/src/components/layout/navigation-bar.tsx
@@ -105,7 +105,7 @@ export function NavigationBar({ stars }: { stars: number | null }) {
 
   return (
     <>
-      <div className="pointer-events-none fixed top-0 right-0 left-0 z-99 flex items-start [scrollbar-gutter:stable]">
+      <div className="pointer-events-none sticky top-0 right-0 left-0 z-99 flex items-start">
         {/* Mobile */}
         <motion.div
           initial={{ opacity: 0 }}


### PR DESCRIPTION
**The issue**

The navbar and the content on the home page have misaligned vertical borders. Image for reference:
<img width="1319" height="100" alt="Screenshot 2026-04-13 at 18 46 11" src="https://github.com/user-attachments/assets/4906b7e2-19d6-48b8-b2c3-7592a71ff107" />

The navbar was `fixed`, so its inner `max-w-[76rem]` container was centered relative to the viewport. The homepage content was inside a separate scrollable container, so its `max-w-[76rem]` sections were centered relative to that scrolling area instead. On pages with a visible scrollbar like `/`, those two widths differ slightly, which makes the side borders look misaligned. I figured this out when i checked `/enterprise` and noticed no issues with the alignment.

**The fix**
The fix was to move the navbar into the same scroll container as the page content and make it `sticky` instead if `fixed.` That way both the navbar border lines and the page border lines are measured and centered "within" the same layout context, so they line up consistently. Image for reference
<img width="1319" height="100" alt="Screenshot 2026-04-13 at 18 49 52" src="https://github.com/user-attachments/assets/a0645e82-f661-49e1-899a-0836f4a4bd06" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated navigation bar positioning to use sticky layout instead of fixed positioning, allowing the navigation to scroll with page content.
  * Removed unnecessary scroll utility from the navigation container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->