### PR TITLE
test(paykit): add unit tests for core utils and error codes

### DIFF
--- a/packages/paykit/src/core/__tests__/errors.test.ts
+++ b/packages/paykit/src/core/__tests__/errors.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { defineErrorCodes } from "../error-codes";
+import { PayKitError, PAYKIT_ERROR_CODES } from "../errors";
+
+describe("core/error-codes", () => {
+  describe("defineErrorCodes", () => {
+    it("produces an object keyed by error code with code and message", () => {
+      const codes = defineErrorCodes({
+        NOT_FOUND: "Resource not found",
+        INVALID_INPUT: "Input is invalid",
+      });
+
+      expect(codes.NOT_FOUND).toEqual(
+        expect.objectContaining({ code: "NOT_FOUND", message: "Resource not found" }),
+      );
+      expect(codes.INVALID_INPUT).toEqual(
+        expect.objectContaining({ code: "INVALID_INPUT", message: "Input is invalid" }),
+      );
+    });
+
+    it("toString returns the code string", () => {
+      const codes = defineErrorCodes({ MY_CODE: "some message" });
+      expect(String(codes.MY_CODE)).toBe("MY_CODE");
+    });
+  });
+
+  describe("PAYKIT_ERROR_CODES", () => {
+    it("includes expected error codes", () => {
+      expect(PAYKIT_ERROR_CODES.CUSTOMER_NOT_FOUND.code).toBe("CUSTOMER_NOT_FOUND");
+      expect(PAYKIT_ERROR_CODES.PLAN_NOT_FOUND.code).toBe("PLAN_NOT_FOUND");
+      expect(PAYKIT_ERROR_CODES.PROVIDER_REQUIRED.code).toBe("PROVIDER_REQUIRED");
+    });
+  });
+
+  describe("PayKitError", () => {
+    it("sets name, code, and message from a RawError", () => {
+      const raw = PAYKIT_ERROR_CODES.CUSTOMER_NOT_FOUND;
+      const error = new PayKitError("BAD_REQUEST", raw);
+
+      expect(error.name).toBe("PayKitError");
+      expect(error.code).toBe("CUSTOMER_NOT_FOUND");
+      expect(error.message).toBe("Customer not found");
+    });
+
+    it("allows overriding the message", () => {
+      const raw = PAYKIT_ERROR_CODES.PLAN_NOT_FOUND;
+      const error = new PayKitError("NOT_FOUND", raw, "Plan 'pro' does not exist");
+
+      expect(error.code).toBe("PLAN_NOT_FOUND");
+      expect(error.message).toBe("Plan 'pro' does not exist");
+    });
+
+    it("can be constructed via the static from helper", () => {
+      const error = PayKitError.from("INTERNAL_SERVER_ERROR", PAYKIT_ERROR_CODES.PROVIDER_REQUIRED);
+
+      expect(error).toBeInstanceOf(PayKitError);
+      expect(error.code).toBe("PROVIDER_REQUIRED");
+    });
+  });
+});

--- a/packages/paykit/src/core/__tests__/utils.test.ts
+++ b/packages/paykit/src/core/__tests__/utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { generateId } from "../utils";
+
+describe("core/utils", () => {
+  describe("generateId", () => {
+    it("returns a string with the given prefix followed by an underscore", () => {
+      const id = generateId("cus");
+      expect(id).toMatch(/^cus_/u);
+    });
+
+    it("uses a default random segment length of 24", () => {
+      const id = generateId("cus");
+      const random = id.slice("cus_".length);
+      expect(random).toHaveLength(24);
+    });
+
+    it("respects a custom random segment length", () => {
+      const id = generateId("pk", 12);
+      const random = id.slice("pk_".length);
+      expect(random).toHaveLength(12);
+    });
+
+    it("only contains alphanumeric characters in the random segment", () => {
+      for (let i = 0; i < 20; i++) {
+        const id = generateId("t", 48);
+        const random = id.slice("t_".length);
+        expect(random).toMatch(/^[0-9A-Za-z]+$/u);
+      }
+    });
+
+    it("produces unique values across calls", () => {
+      const ids = new Set(Array.from({ length: 100 }, () => generateId("u")));
+      expect(ids.size).toBe(100);
+    });
+  });
+});


### PR DESCRIPTION
Looking forward to the Polar integration, thought I'd help where I could while waiting!

Added unit tests for two untested core modules:
- `core/utils.ts`: 5 tests for `generateId` covering prefix format, default/custom length, alphabet constraints, and uniqueness.
- `core/error-codes.ts` / `errors.ts`: 6 tests for `defineErrorCodes` shape and `toString`, `PAYKIT_ERROR_CODES` spot-checks, and `PayKitError` construction (including message override and static from).

All tests pass, AI was not used for writing this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for error handling functionality, validating error code definitions, error messages, error construction, and error instantiation mechanisms.
  * Added thorough test coverage for the ID generation utility, verifying proper prefix formatting, configurable random segment lengths, alphanumeric character validation, and uniqueness across multiple invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->