### PR TITLE
docs(stripe): list required webhook events

### DIFF
--- a/landing/content/docs/providers/stripe.mdx
+++ b/landing/content/docs/providers/stripe.mdx
@@ -46,7 +46,24 @@ In the Stripe Dashboard, go to **Developers > Webhooks** and create a new endpoi
 https://your-app.com/paykit/api/webhook
 ```
 
-You can select all events or just the ones PayKit needs. After saving, Stripe displays the signing secret. Copy it as your `STRIPE_WEBHOOK_SECRET`.
+Select the following events when creating the endpoint:
+
+- `checkout.session.completed`
+- `customer.subscription.created`
+- `customer.subscription.updated`
+- `customer.subscription.deleted`
+- `invoice.created`
+- `invoice.finalized`
+- `invoice.paid`
+- `invoice.payment_failed`
+- `invoice.updated`
+- `payment_method.detached`
+
+<Callout>
+  Stripe discourages selecting all events as it may cause performance issues. Only the events listed above are required by PayKit.
+</Callout>
+
+After saving, Stripe displays the signing secret. Copy it as your `STRIPE_WEBHOOK_SECRET`.
 
 ## Local development
 

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "typecheck": "turbo run typecheck",
-    "format": "oxfmt --write",
-    "format:check": "oxfmt --check",
+    "format": "oxfmt --write '**/*.{ts,tsx,js,jsx}'",
+    "format:check": "oxfmt --check '**/*.{ts,tsx,js,jsx}'",
     "lint": "oxlint --deny-warnings",
     "lint:fix": "oxlint --fix",
     "release": "turbo build --filter=./packages/* && bumpp",
@@ -38,10 +38,8 @@
     "pre-commit": "pnpm lint-staged"
   },
   "lint-staged": {
-    "!(**/migrations/**)": [
-      "oxlint --fix",
-      "oxfmt --write"
-    ]
+    "!(**/migrations/**)": "oxlint --fix",
+    "*.{ts,tsx,js,jsx}": "oxfmt --write"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Summary
- Lists the 10 specific Stripe webhook events PayKit needs in the Stripe provider docs (`#webhook-setup` section)
- Scopes `oxfmt` to code files only (`*.{ts,tsx,js,jsx}`) in both global scripts and lint-staged to avoid errors on MDX files

Closes #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Stripe webhook setup instructions to specify required event types instead of selecting all events, with guidance on Stripe's performance recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->