### PR TITLE
fix(landing): docs layout fixes — sidebar, subnav, TOC, robots

### DIFF
--- a/landing/src/styles/globals.css
+++ b/landing/src/styles/globals.css
@@ -375,10 +375,6 @@ html:not([data-anchor-scrolling]) {
 
 /* Sidebar: fixed positioning so it never scrolls with content, but only when expanded */
 @media (min-width: 768px) {
-  #nd-sidebar {
-    will-change: transform;
-  }
-
   [data-sidebar-placeholder]:not(:has(#nd-sidebar[data-collapsed="true"])) {
     position: fixed !important;
     width: var(--fd-sidebar-width) !important;
@@ -388,6 +384,7 @@ html:not([data-anchor-scrolling]) {
 
 @media (max-width: 767px) {
   #nd-subnav {
+    --subnav-height: 3.5rem;
     position: fixed !important;
     top: var(--fd-docs-row-1, 0px) !important;
     inset-inline-start: 0 !important;
@@ -396,7 +393,7 @@ html:not([data-anchor-scrolling]) {
 
   /* Compensate for fixed #nd-subnav leaving grid flow */
   [data-toc-popover] {
-    margin-top: 3.5rem;
+    margin-top: var(--subnav-height, 3.5rem);
   }
 }
 

--- a/landing/src/styles/globals.css
+++ b/landing/src/styles/globals.css
@@ -373,12 +373,30 @@ html:not([data-anchor-scrolling]) {
   display: none;
 }
 
-/* Sticky positioning is broken inside the fumadocs grid. Use fixed instead. */
+/* Sidebar: fixed positioning so it never scrolls with content, but only when expanded */
 @media (min-width: 768px) {
-  [data-sidebar-placeholder] {
+  #nd-sidebar {
+    will-change: transform;
+  }
+
+  [data-sidebar-placeholder]:not(:has(#nd-sidebar[data-collapsed="true"])) {
     position: fixed !important;
     width: var(--fd-sidebar-width) !important;
     inset-inline-start: max(0px, calc((100vw - var(--fd-layout-width, 97rem)) / 2)) !important;
+  }
+}
+
+@media (max-width: 767px) {
+  #nd-subnav {
+    position: fixed !important;
+    top: var(--fd-docs-row-1, 0px) !important;
+    inset-inline-start: 0 !important;
+    inset-inline-end: 0 !important;
+  }
+
+  /* Compensate for fixed #nd-subnav leaving grid flow */
+  [data-toc-popover] {
+    margin-top: 3.5rem;
   }
 }
 

--- a/landing/src/styles/globals.css
+++ b/landing/src/styles/globals.css
@@ -383,8 +383,11 @@ html:not([data-anchor-scrolling]) {
 }
 
 @media (max-width: 767px) {
-  #nd-subnav {
+  :root {
     --subnav-height: 3.5rem;
+  }
+
+  #nd-subnav {
     position: fixed !important;
     top: var(--fd-docs-row-1, 0px) !important;
     inset-inline-start: 0 !important;
@@ -393,7 +396,7 @@ html:not([data-anchor-scrolling]) {
 
   /* Compensate for fixed #nd-subnav leaving grid flow */
   [data-toc-popover] {
-    margin-top: var(--subnav-height, 3.5rem);
+    margin-top: var(--subnav-height);
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix sidebar fixed positioning to only apply when expanded (not collapsed)
- Fix mobile subnav to top with proper TOC popover margin compensation
- Make TOC popover header fixed so it doesn't scroll with content
- Stabilize sidebar background color and fix typo
- Use .md instead of .mdx for docs markdown routes
- Disallow crawling of Next.js static media in robots.txt
- Prevent docs sidebar from scrolling with page content

## Test plan
- [ ] Verify sidebar stays fixed on desktop when expanded, behaves normally when collapsed
- [ ] Verify mobile subnav is fixed to top and TOC popover spacing is correct
- [ ] Verify TOC popover header stays fixed when scrolling
- [ ] Check robots.txt blocks `/_next/static/media/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar placeholder now only locks into a fixed position when the sidebar is expanded, reducing unexpected layout shifts on larger screens.
  * Mobile sub-navigation is fixed to the top of the viewport for consistent access while scrolling.
  * Table-of-contents popovers receive added top spacing to prevent overlap with the fixed mobile sub-navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->