### PR TITLE
docs: replace better-auth plugin reference with polar provider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ docs: update README setup steps
 chore: bump pnpm to 10.4.1
 ```
 
-The scope is the **package name** (`paykit`, `stripe`, `dash`, `better-auth`).
++The scope is the **package name** (`paykit`, `stripe`, `dash`, `polar`).
 
 - PRs target `main`
 - For bug fixes or non-breaking improvements, a PR is enough

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ packages/
   paykit/       # Core orchestration package
   stripe/       # Stripe provider
   dash/         # Dashboard
-  better-auth/  # Better Auth plugin
+  polar/  # Polar provider
 apps/
   demo/         # Demo app
 landing/        # Next.js marketing site


### PR DESCRIPTION
This pull request updates the documentation to reflect a change in the provider packages. Specifically, it replaces the reference to the "Better Auth" plugin with the new "Polar" provider in the `CONTRIBUTING.md` file.

Documentation update:

* Updated the package list in `CONTRIBUTING.md` to replace `better-auth/` with `polar/` to accurately reflect the current set of provider packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Contributor guide updated: replaced the package name "better-auth" with "polar" in the listed packages and in Conventional Commits scope examples. This brings documentation in line with the current package naming and clarifies commit-scope guidance for contributors, reducing ambiguity when selecting package scopes and understanding available packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->