### PR TITLE
chore: replace better-auth plugin reference with polar provider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ packages/
   paykit/       # Core orchestration package
   stripe/       # Stripe provider
   dash/         # Dashboard
-  better-auth/  # Better Auth plugin
+  polar/  # Polar provider
 apps/
   demo/         # Demo app
 landing/        # Next.js marketing site
@@ -86,7 +86,7 @@ docs: update README setup steps
 chore: bump pnpm to 10.4.1
 ```
 
-The scope is the **package name** (`paykit`, `stripe`, `dash`, `better-auth`).
+The scope is the **package name** (`paykit`, `stripe`, `dash`, `polar`).
 
 - PRs target `main`
 - For bug fixes or non-breaking improvements, a PR is enough


### PR DESCRIPTION
## Summary

Updates `CONTRIBUTING.md` to reflect the current provider packages:

- Replaces the stale `better-auth/` reference in the monorepo structure with `polar/`
- Updates the scope examples in the commit conventions section to use current package names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guidelines to reference the monorepo package as "polar" instead of "better-auth".
  * Adjusted Conventional Commits scope examples to use "polar".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->