### PR TITLE
chore: extract worktree setup into shell script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "release": "turbo build --filter=./packages/* && bumpp",
     "release:canary": "turbo build --filter=./packages/* && bumpp --tag canary",
     "prepare": "simple-git-hooks",
-    "tree-setup": "cp $ROOT_PATH/.env ./ && cp $ROOT_PATH/landing/.env ./landing/ && cp $ROOT_PATH/apps/demo/.env ./apps/demo/ && ln -s '/Users/maxktz/Library/Mobile Documents/com~apple~CloudDocs/PayKit/paykit-docs' ob && pnpm install"
+    "worktree:setup": "bash scripts/worktree-setup.sh"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(git worktree list | head -1 | awk '{print $1}')
+
+ln -sf "$ROOT/.env" ./
+ln -sf "$ROOT/landing/.env" ./landing/
+ln -sf "$ROOT/apps/demo/.env" ./apps/demo/
+ln -sf "$ROOT/ob" ./ob
+pnpm install


### PR DESCRIPTION
Auto-discovers root worktree via git, symlinks .env files and ob directory. Idempotent — safe to re-run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored development setup process to use a dedicated initialization script, improving configuration management and ensuring consistent setup across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->