### PR TITLE
Add tanstack route example in docs

### DIFF
--- a/landing/content/docs/get-started/installation.mdx
+++ b/landing/content/docs/get-started/installation.mdx
@@ -106,13 +106,14 @@ Create a new file or route in your framework's designated catch-all route handle
   </Tab>
   <Tab value="Tanstack Start">
     ```ts title="src/routes/paykit.$.ts"
-    import { paykit } from "./paykit";
+   import { createFileRoute } from "@tanstack/react-router";
+   import { paykit } from "@/lib/paykit";
 
     async function handle({ request }: { request: Request }) {
         return paykit.handler(request)
     }
     
-    export const Route = createFileRoute("/paykit.$.ts")({
+    export const Route = createFileRoute("/paykit/$")({
       server: {
         handlers: {
           GET: handle,

--- a/landing/content/docs/get-started/installation.mdx
+++ b/landing/content/docs/get-started/installation.mdx
@@ -95,13 +95,31 @@ To handle webhooks and client API requests, you need to set up a request handler
 
 Create a new file or route in your framework's designated catch-all route handler. This route should handle requests for the path /paykit/* (unless you've configured a different base path).
 
-<Tabs items={["Next.js", "Other"]}>
+<Tabs items={["Next.js", "Tanstack Start", "Other"]}>
   <Tab value="Next.js">
     ```ts title="src/app/paykit/[[...slug]]/route.ts"
     import { paykitHandler } from "paykitjs/handlers/next";
     import { paykit } from "@/lib/paykit";
 
     export const { GET, POST } = paykitHandler(paykit);
+    ```
+  </Tab>
+  <Tab value="Tanstack Start">
+    ```ts title="src/routes/paykit.$.ts"
+    import { paykit } from "./paykit";
+
+    async function handle({ request }: { request: Request }) {
+        return paykit.handler(request)
+    }
+    
+    export const Route = createFileRoute("/paykit.$.ts")({
+      server: {
+        handlers: {
+          GET: handle,
+          POST: handle,
+        },
+      },
+    });
     ```
   </Tab>
   <Tab value="Other">


### PR DESCRIPTION
I've added a tab for tanstack start/router on how to set paykit as an api route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a TanStack Start integration example to the installation guide. A new tab demonstrates creating a route, mounting a request handler, and registering it to handle both GET and POST requests. Existing Next.js and alternative examples remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->