### PR TITLE
Enable brand menu on mobile headers

### DIFF
--- a/apps/web/src/components/layout/mini-nav-bar.tsx
+++ b/apps/web/src/components/layout/mini-nav-bar.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import Link from "next/link";
 
-import { Wordmark } from "@/components/icons/wordmark";
 import { BrandMenu } from "@/components/web/brand-menu";
 
 import { SectionShell } from "./section";
@@ -18,9 +16,7 @@ export function MiniNavBar() {
         className="bg-background border-border pointer-events-auto w-full border-b lg:hidden"
       >
         <SectionShell className="flex items-center">
-          <Link href="/" aria-label="PayKit home" className="flex items-center gap-1 px-5 py-3">
-            <Wordmark title={null} className="h-4 origin-left scale-95" />
-          </Link>
+          <BrandMenu linkClassName="gap-1 px-5 py-3" wordmarkClassName="scale-95" />
         </SectionShell>
       </motion.div>
 

--- a/apps/web/src/components/layout/navigation-bar.tsx
+++ b/apps/web/src/components/layout/navigation-bar.tsx
@@ -112,9 +112,7 @@ export function NavigationBar({ stars: _stars }: { stars: number | null }) {
           className="bg-background border-border pointer-events-auto w-full border-b lg:hidden"
         >
           <SectionShell className="flex items-center justify-between">
-            <Link href="/" aria-label="PayKit home" className="flex items-center gap-1 px-5 py-3">
-              <Wordmark title={null} className="h-4 origin-left scale-95" />
-            </Link>
+            <BrandMenu linkClassName="gap-1 px-5 py-3" wordmarkClassName="scale-95" />
             <button
               type="button"
               aria-label={mobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}

--- a/apps/web/src/components/web/brand-menu.tsx
+++ b/apps/web/src/components/web/brand-menu.tsx
@@ -13,6 +13,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { cn } from "@/lib/utils";
 
 type BrandAsset = "Logo" | "Wordmark";
 
@@ -21,7 +22,15 @@ const brandAssets = {
   Wordmark: WORDMARK_SVG,
 };
 
-export function BrandMenu() {
+export function BrandMenu({
+  className,
+  linkClassName,
+  wordmarkClassName,
+}: {
+  className?: string;
+  linkClassName?: string;
+  wordmarkClassName?: string;
+}) {
   const logoRef = useRef<HTMLAnchorElement>(null);
 
   async function copyAsSvg(asset: BrandAsset) {
@@ -36,7 +45,7 @@ export function BrandMenu() {
   }
 
   return (
-    <div className="z-10 flex items-center">
+    <div className={cn("z-10 flex items-center", className)}>
       <ContextMenu>
         <ContextMenuTrigger
           className="flex items-center"
@@ -45,9 +54,9 @@ export function BrandMenu() {
               ref={logoRef}
               href="/"
               aria-label="PayKit home"
-              className="flex items-center py-1.5"
+              className={cn("flex items-center py-1.5", linkClassName)}
             >
-              <Wordmark title={null} className="h-4 origin-left" />
+              <Wordmark title={null} className={cn("h-4 origin-left", wordmarkClassName)} />
             </Link>
           }
         />


### PR DESCRIPTION
## Summary
- enable the shared brand context menu in the mobile main header and mini header
- reuse `BrandMenu` across header variants so copy logo / copy wordmark works consistently on small screens too
- keep the existing mobile spacing and wordmark sizing aligned with the current header styles

## Testing
- `bun typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined navigation component structure by consolidating brand menu and logo rendering logic, improving code reusability and maintainability across navigation components while enabling flexible styling customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->