### PR TITLE
feat(landing): theme toggle support for landing

### DIFF
--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -7,7 +7,7 @@ import { PageTransition } from "@/components/layout/page-transition";
 export default function MarketingLayout({ children }: { children: ReactNode }) {
   return (
     <CommandMenuProvider>
-      <div className="dark bg-background text-foreground min-h-dvh overflow-x-hidden">
+      <div className="bg-background text-foreground min-h-dvh overflow-x-hidden">
         <NavigationBar stars={null} />
         <main>
           <PageTransition>{children}</PageTransition>

--- a/apps/web/src/components/layout/navigation-bar.tsx
+++ b/apps/web/src/components/layout/navigation-bar.tsx
@@ -11,6 +11,8 @@ import { Button } from "@/components/ui/button";
 import { BrandMenu } from "@/components/web/brand-menu";
 import { URLs } from "@/lib/consts";
 
+import { ThemeToggle } from "../theme-toggle";
+
 // ─── Shared nav link ─────────────────────────────────────────────────
 
 interface NavItem {
@@ -223,6 +225,7 @@ export function NavigationBar({ stars: _stars }: { stars: number | null }) {
                   <Github className="size-3.5" />
                   <span>GitHub</span>
                 </Button>
+                <ThemeToggle />
               </div>
             </div>
           </SectionShell>

--- a/apps/web/src/components/layout/navigation-bar.tsx
+++ b/apps/web/src/components/layout/navigation-bar.tsx
@@ -113,16 +113,19 @@ export function NavigationBar({ stars: _stars }: { stars: number | null }) {
         >
           <SectionShell className="flex items-center justify-between">
             <BrandMenu linkClassName="gap-1 px-5 py-3" wordmarkClassName="scale-95" />
-            <button
-              type="button"
-              aria-label={mobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}
-              aria-controls="mobile-navigation-menu"
-              aria-expanded={mobileMenuOpen}
-              onClick={() => setMobileMenuOpen((prev) => !prev)}
-              className="text-foreground/65 dark:text-foreground/50 hover:text-foreground/80 px-5 py-3 transition-colors"
-            >
-              {mobileMenuOpen ? <X size={18} /> : <Menu size={18} />}
-            </button>
+            <div className="flex items-center justify-center">
+              <ThemeToggle />
+              <button
+                type="button"
+                aria-label={mobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}
+                aria-controls="mobile-navigation-menu"
+                aria-expanded={mobileMenuOpen}
+                onClick={() => setMobileMenuOpen((prev) => !prev)}
+                className="text-foreground/65 dark:text-foreground/50 hover:text-foreground/80 px-5 py-3 transition-colors"
+              >
+                {mobileMenuOpen ? <X size={18} /> : <Menu size={18} />}
+              </button>
+            </div>
           </SectionShell>
         </motion.div>
 
@@ -148,7 +151,11 @@ export function NavigationBar({ stars: _stars }: { stars: number | null }) {
                         key={item.name}
                         initial={{ opacity: 0, y: -4 }}
                         animate={{ opacity: 1, y: 0 }}
-                        transition={{ duration: 0.2, delay: 0.05 + i * 0.03, ease: "easeOut" }}
+                        transition={{
+                          duration: 0.2,
+                          delay: 0.05 + i * 0.03,
+                          ease: "easeOut",
+                        }}
                       >
                         <NavLink
                           item={item}


### PR DESCRIPTION
Issue : #75
now a user can toggle both light or dark mode accordingly. 

dark mode : 
<img width="1896" height="1080" alt="screenshot-2026-05-12_16-25-16" src="https://github.com/user-attachments/assets/c6a83fcc-a71c-4b81-a9a2-f941b6578adb" />

light mode :
<img width="1906" height="1069" alt="screenshot-2026-05-12_16-25-27" src="https://github.com/user-attachments/assets/cb1e4dfd-27ef-4225-9346-15e1ee1950a6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme toggle added to the navigation bar (visible on mobile and desktop) so users can switch between light and dark modes.

* **Bug Fixes / Behavior Change**
  * Root layout no longer forces dark styling by default, allowing the app to respect the selected theme.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getpaykit/paykit/pull/177)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->