### PR TITLE
fix(web): update env example

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -12,3 +12,11 @@
 # Example:
 # SERVERVAR="foo"
 # NEXT_PUBLIC_CLIENTVAR="bar"
+
+RESEND_API_KEY=""
+
+# Optional; defaults to "contact@paykit.sh"
+# RESEND_FROM_EMAIL="contact@paykit.sh"
+
+# Optional; defaults to "contact@paykit.sh"
+# RESEND_TO_EMAIL="contact@paykit.sh"


### PR DESCRIPTION
## Summary
- update `apps/web/.env.example` with the env variable actually required to build and run the web app
- document `RESEND_FROM_EMAIL` and `RESEND_TO_EMAIL` as optional overrides because the app provides defaults for both

## Why
The existing example file did not reflect the real env contract used by `apps/web`, which made local setup unclear.

## Validation
- `bun run build` in `apps/web` fails without `RESEND_API_KEY`
- `env RESEND_API_KEY=dummy bun run build` in `apps/web` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added example environment variables for email service configuration, including API key and optional email address settings for initial project setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getpaykit/paykit/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->