### PR TITLE
feat(docs): add custom docs 404 page

### DIFF
--- a/apps/web/src/app/docs/not-found.tsx
+++ b/apps/web/src/app/docs/not-found.tsx
@@ -1,0 +1,47 @@
+import { ArrowLeft, BookOpenText, House } from "lucide-react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+
+export default function DocsNotFound() {
+  return (
+    <div className="flex min-h-[calc(100dvh-var(--fd-nav-height))] items-center justify-center px-6 py-16">
+      <Empty className="border-border/60 bg-card/40 mx-auto max-w-xl rounded-2xl border border-dashed">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <BookOpenText className="size-4" />
+          </EmptyMedia>
+          <EmptyTitle className="text-base sm:text-lg">Documentation page not found</EmptyTitle>
+          <EmptyDescription>
+            The docs page you requested does not exist or may have moved. Start from the docs index
+            or head back to the homepage.
+          </EmptyDescription>
+        </EmptyHeader>
+
+        <EmptyContent className="sm:flex-row sm:justify-center">
+          <Button render={<Link href="/docs/get-started" />} nativeButton={false}>
+            <BookOpenText />
+            Open docs
+          </Button>
+          <Button render={<Link href="/" />} nativeButton={false} variant="ghost">
+            <House />
+            Go home
+          </Button>
+        </EmptyContent>
+
+        <div className="text-muted-foreground flex items-center gap-2 text-xs">
+          <ArrowLeft className="size-3.5" />
+          Try the sidebar or search to find another page.
+        </div>
+      </Empty>
+    </div>
+  );
+}


### PR DESCRIPTION
This adds a docs-specific 404 page so missing routes under `/docs` no longer fall back to the generic site-wide not found screen.

I kept it inside the docs layout and reused the existing empty-state components, with quick links back to `/docs/get-started` and `/`.

Validation:
- `bun run typecheck` in `apps/web`
- `env RESEND_API_KEY=dummy bun run build` in `apps/web`

Closes #70


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a styled documentation not-found page with navigation buttons to the getting started guide and home, plus a helpful note guiding users to use the sidebar or search functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getpaykit/paykit/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->