### PR TITLE
feat(paykit): add Stripe currency support

### DIFF
--- a/e2e/cli/push.test.ts
+++ b/e2e/cli/push.test.ts
@@ -73,12 +73,13 @@ describe("paykitjs push", () => {
           name: product.name,
           group: product.group,
           is_default: product.isDefault,
+          priceCurrency: product.priceCurrency,
         })
         .from(product)
         .orderBy(asc(product.id));
       expect(dbRows).toEqual([
-        { id: "free", name: "Free", group: "base", is_default: true },
-        { id: "pro", name: "Pro", group: "base", is_default: false },
+        { id: "free", name: "Free", group: "base", is_default: true, priceCurrency: null },
+        { id: "pro", name: "Pro", group: "base", is_default: false, priceCurrency: "usd" },
       ]);
 
       // Verify paid plan (pro) was synced to Stripe.
@@ -112,6 +113,48 @@ describe("paykitjs push", () => {
 
       const hasChanges = diffs.some((d) => d.action !== "unchanged");
       expect(hasChanges).toBe(false);
+    } finally {
+      await database.end();
+    }
+  });
+
+  it("should sync eur prices to the database and Stripe", async () => {
+    const config = await getPayKitConfig({ cwd: fixture.cwd });
+    const database = resolveDatabase(config.options.database);
+    try {
+      const ctx = await createContext({
+        ...config.options,
+        database,
+        stripe: {
+          ...config.options.stripe,
+          currency: "eur",
+        },
+      });
+      const results = await syncProducts(ctx);
+
+      const proResult = results.find((r) => r.id === "pro");
+      expect(proResult).toMatchObject({ action: "created", version: 2 });
+
+      const proRows = await ctx.database
+        .select({
+          priceCurrency: product.priceCurrency,
+          stripePriceId: product.stripePriceId,
+        })
+        .from(product)
+        .where(eq(product.id, "pro"))
+        .orderBy(desc(product.version))
+        .limit(1);
+      const proProduct = proRows[0];
+      expect(proProduct?.priceCurrency).toBe("eur");
+      if (!proProduct?.stripePriceId) {
+        throw new Error("Missing Stripe price metadata for synced EUR plan");
+      }
+
+      const stripePrice = await fixture.stripeClient.prices.retrieve(proProduct.stripePriceId);
+      expect(stripePrice.currency).toBe("eur");
+
+      const diffs = await dryRunSyncProducts(ctx);
+      expect(diffs.find((d) => d.id === "pro")?.action).toBe("unchanged");
     } finally {
       await database.end();
     }

--- a/packages/paykit/src/cli/__tests__/format.test.ts
+++ b/packages/paykit/src/cli/__tests__/format.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { formatPrice } from "../utils/format";
+
+describe("cli/format", () => {
+  it("formats monthly prices in eur", () => {
+    expect(formatPrice(2900, "month", "eur")).toBe("€29/mo");
+  });
+
+  it("formats decimal prices in eur", () => {
+    expect(formatPrice(2999, "month", "eur")).toBe("€29.99/mo");
+  });
+});

--- a/packages/paykit/src/cli/utils/format.ts
+++ b/packages/paykit/src/cli/utils/format.ts
@@ -12,9 +12,18 @@ export function maskConnectionString(url: string): string {
   }
 }
 
-export function formatPrice(amountCents: number, interval: string | null): string {
+export function formatPrice(
+  amountCents: number,
+  interval: string | null,
+  currency = "usd",
+): string {
   const dollars = amountCents / 100;
-  const formatted = dollars % 1 === 0 ? `$${dollars}` : `$${dollars.toFixed(2)}`;
+  const formatted = new Intl.NumberFormat("en-US", {
+    currency: currency.toUpperCase(),
+    maximumFractionDigits: dollars % 1 === 0 ? 0 : 2,
+    minimumFractionDigits: dollars % 1 === 0 ? 0 : 2,
+    style: "currency",
+  }).format(dollars);
   if (!interval) {
     return formatted;
   }

--- a/packages/paykit/src/cli/utils/shared.ts
+++ b/packages/paykit/src/cli/utils/shared.ts
@@ -81,7 +81,9 @@ export function formatProductDiffs(
   const productsById = new Map(products.map((pl) => [pl.id, pl]));
   return diffs.map((diff) => {
     const plan = productsById.get(diff.id);
-    const price = plan ? deps.formatPrice(plan.priceAmount ?? 0, plan.priceInterval) : "$0";
+    const price = plan
+      ? deps.formatPrice(plan.priceAmount ?? 0, plan.priceInterval, plan.priceCurrency ?? "usd")
+      : "$0";
     return deps.formatPlanLine(diff.action, diff.id, price);
   });
 }

--- a/packages/paykit/src/core/__tests__/validate-options.test.ts
+++ b/packages/paykit/src/core/__tests__/validate-options.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import type { PayKitOptions } from "../../types/options";
+import { assertValidPayKitOptions } from "../validate-options";
+
+function createOptions(currency?: string): PayKitOptions {
+  return {
+    database: "postgresql://localhost:5432/paykit",
+    stripe: {
+      ...(currency ? { currency: currency as never } : {}),
+      secretKey: "sk_test_123",
+      webhookSecret: "whsec_123",
+    },
+  };
+}
+
+describe("core/validate-options", () => {
+  it("accepts usd and eur Stripe currencies", () => {
+    expect(() => assertValidPayKitOptions(createOptions("usd"))).not.toThrow();
+    expect(() => assertValidPayKitOptions(createOptions("eur"))).not.toThrow();
+  });
+
+  it("rejects unsupported Stripe currencies", () => {
+    expect(() => assertValidPayKitOptions(createOptions("gbp"))).toThrow(
+      "currently supports Stripe currencies: usd, eur",
+    );
+  });
+
+  it("rejects non-lowercase Stripe currencies", () => {
+    expect(() => assertValidPayKitOptions(createOptions("EUR"))).toThrow(
+      "must be a lowercase three-letter currency code",
+    );
+  });
+});

--- a/packages/paykit/src/core/__tests__/validate-options.test.ts
+++ b/packages/paykit/src/core/__tests__/validate-options.test.ts
@@ -7,7 +7,7 @@ function createOptions(currency?: string): PayKitOptions {
   return {
     database: "postgresql://localhost:5432/paykit",
     stripe: {
-      ...(currency ? { currency: currency as never } : {}),
+      ...(currency !== undefined ? { currency: currency as never } : {}),
       secretKey: "sk_test_123",
       webhookSecret: "whsec_123",
     },
@@ -28,6 +28,12 @@ describe("core/validate-options", () => {
 
   it("rejects non-lowercase Stripe currencies", () => {
     expect(() => assertValidPayKitOptions(createOptions("EUR"))).toThrow(
+      "must be a lowercase three-letter currency code",
+    );
+  });
+
+  it("rejects empty Stripe currency", () => {
+    expect(() => assertValidPayKitOptions(createOptions(""))).toThrow(
       "must be a lowercase three-letter currency code",
     );
   });

--- a/packages/paykit/src/core/context.ts
+++ b/packages/paykit/src/core/context.ts
@@ -2,6 +2,7 @@ import { Pool } from "pg";
 
 import { createDatabase, type PayKitDatabase } from "../database/index";
 import type { PaymentProvider } from "../providers/provider";
+import { getStripeCurrency } from "../stripe/currency";
 import { createStripeAdapter } from "../stripe/stripe-provider";
 import type { PayKitOptions } from "../types/options";
 import { normalizeSchema, type NormalizedSchema } from "../types/schema";
@@ -43,7 +44,9 @@ export async function createContext(options: PayKitOptions): Promise<PayKitConte
     basePath,
     database,
     provider,
-    products: normalizeSchema(options.products),
+    products: normalizeSchema(options.products, {
+      priceCurrency: getStripeCurrency(options.stripe),
+    }),
     logger: createPayKitLogger(options.logging),
   };
 }

--- a/packages/paykit/src/core/validate-options.ts
+++ b/packages/paykit/src/core/validate-options.ts
@@ -1,3 +1,4 @@
+import { isSupportedStripeCurrency, SUPPORTED_STRIPE_CURRENCIES } from "../stripe/currency";
 import type { PayKitOptions } from "../types/options";
 
 function hasLegacyPlansOption(options: object): options is { plans: unknown } {
@@ -27,6 +28,24 @@ export function assertValidPayKitOptions(
 
   for (const origin of options.trustedOrigins ?? []) {
     assertValidTrustedOrigin(origin);
+  }
+
+  if (options.stripe?.currency) {
+    assertValidStripeCurrency(options.stripe.currency);
+  }
+}
+
+function assertValidStripeCurrency(currency: string): void {
+  if (currency !== currency.toLowerCase() || !/^[a-z]{3}$/.test(currency)) {
+    throw new Error(
+      `PayKit option \`stripe.currency\` must be a lowercase three-letter currency code. Received "${currency}".`,
+    );
+  }
+
+  if (!isSupportedStripeCurrency(currency)) {
+    throw new Error(
+      `PayKit currently supports Stripe currencies: ${SUPPORTED_STRIPE_CURRENCIES.join(", ")}. Received "${currency}".`,
+    );
   }
 }
 

--- a/packages/paykit/src/core/validate-options.ts
+++ b/packages/paykit/src/core/validate-options.ts
@@ -30,15 +30,21 @@ export function assertValidPayKitOptions(
     assertValidTrustedOrigin(origin);
   }
 
-  if (options.stripe?.currency) {
-    assertValidStripeCurrency(options.stripe.currency);
+  const currency = options.stripe?.currency;
+  if (currency !== undefined) {
+    assertValidStripeCurrency(currency);
   }
 }
 
-function assertValidStripeCurrency(currency: string): void {
-  if (currency !== currency.toLowerCase() || !/^[a-z]{3}$/.test(currency)) {
+function assertValidStripeCurrency(currency: unknown): void {
+  if (
+    typeof currency !== "string" ||
+    currency !== currency.toLowerCase() ||
+    !/^[a-z]{3}$/.test(currency)
+  ) {
+    const received = typeof currency === "string" ? currency : String(currency);
     throw new Error(
-      `PayKit option \`stripe.currency\` must be a lowercase three-letter currency code. Received "${currency}".`,
+      `PayKit option \`stripe.currency\` must be a lowercase three-letter currency code. Received "${received}".`,
     );
   }
 

--- a/packages/paykit/src/customer/customer.service.ts
+++ b/packages/paykit/src/customer/customer.service.ts
@@ -11,7 +11,7 @@ import {
   product,
   subscription,
 } from "../database/schema";
-import { getProductByHash } from "../product/product.service";
+import { getProductByPlan } from "../product/product.service";
 import type { ProviderCustomer } from "../providers/provider";
 import {
   getActiveSubscriptionInGroup,
@@ -160,7 +160,7 @@ export async function ensureDefaultPlansForCustomer(
       continue;
     }
 
-    const storedPlan = await getProductByHash(ctx.database, defaultPlan.id, defaultPlan.hash);
+    const storedPlan = await getProductByPlan(ctx.database, defaultPlan);
     if (!storedPlan) {
       continue;
     }

--- a/packages/paykit/src/database/migrations/0002_add-product-price-currency.sql
+++ b/packages/paykit/src/database/migrations/0002_add-product-price-currency.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "paykit_product" ADD COLUMN "price_currency" text;--> statement-breakpoint
+UPDATE "paykit_product"
+SET "price_currency" = 'usd'
+WHERE "price_amount" IS NOT NULL;

--- a/packages/paykit/src/database/migrations/meta/0002_snapshot.json
+++ b/packages/paykit/src/database/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1352 @@
+{
+  "id": "e6a25108-0c13-4942-a2a0-f77eb0692c00",
+  "prevId": "f20b685c-77de-49ad-903d-6dc82acf06be",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.paykit_customer": {
+      "name": "paykit_customer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_test_clock_id": {
+          "name": "stripe_test_clock_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_frozen_time": {
+          "name": "stripe_frozen_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_synced_email": {
+          "name": "stripe_synced_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_synced_name": {
+          "name": "stripe_synced_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_synced_metadata": {
+          "name": "stripe_synced_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "paykit_customer_deleted_at_idx": {
+          "name": "paykit_customer_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_customer_stripe_customer_idx": {
+          "name": "paykit_customer_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_customer_stripe_test_clock_idx": {
+          "name": "paykit_customer_stripe_test_clock_idx",
+          "columns": [
+            {
+              "expression": "stripe_test_clock_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paykit_entitlement": {
+      "name": "paykit_entitlement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit": {
+          "name": "limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reset_at": {
+          "name": "next_reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "paykit_entitlement_subscription_idx": {
+          "name": "paykit_entitlement_subscription_idx",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_entitlement_customer_feature_idx": {
+          "name": "paykit_entitlement_customer_feature_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_entitlement_next_reset_idx": {
+          "name": "paykit_entitlement_next_reset_idx",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "paykit_entitlement_subscription_id_paykit_subscription_id_fk": {
+          "name": "paykit_entitlement_subscription_id_paykit_subscription_id_fk",
+          "tableFrom": "paykit_entitlement",
+          "tableTo": "paykit_subscription",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "paykit_entitlement_customer_id_paykit_customer_id_fk": {
+          "name": "paykit_entitlement_customer_id_paykit_customer_id_fk",
+          "tableFrom": "paykit_entitlement",
+          "tableTo": "paykit_customer",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "paykit_entitlement_feature_id_paykit_feature_id_fk": {
+          "name": "paykit_entitlement_feature_id_paykit_feature_id_fk",
+          "tableFrom": "paykit_entitlement",
+          "tableTo": "paykit_feature",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paykit_feature": {
+      "name": "paykit_feature",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paykit_invoice": {
+      "name": "paykit_invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hosted_url": {
+          "name": "hosted_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_start_at": {
+          "name": "period_start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end_at": {
+          "name": "period_end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "paykit_invoice_customer_idx": {
+          "name": "paykit_invoice_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_invoice_subscription_idx": {
+          "name": "paykit_invoice_subscription_idx",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_invoice_stripe_invoice_idx": {
+          "name": "paykit_invoice_stripe_invoice_idx",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_invoice_stripe_payment_idx": {
+          "name": "paykit_invoice_stripe_payment_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "paykit_invoice_customer_id_paykit_customer_id_fk": {
+          "name": "paykit_invoice_customer_id_paykit_customer_id_fk",
+          "tableFrom": "paykit_invoice",
+          "tableTo": "paykit_customer",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "paykit_invoice_subscription_id_paykit_subscription_id_fk": {
+          "name": "paykit_invoice_subscription_id_paykit_subscription_id_fk",
+          "tableFrom": "paykit_invoice",
+          "tableTo": "paykit_subscription",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paykit_metadata": {
+      "name": "paykit_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "paykit_metadata_stripe_checkout_session_unique": {
+          "name": "paykit_metadata_stripe_checkout_session_unique",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paykit_payment_method": {
+      "name": "paykit_payment_method",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_month": {
+          "name": "expiry_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_year": {
+          "name": "expiry_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "paykit_payment_method_customer_idx": {
+          "name": "paykit_payment_method_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_payment_method_stripe_payment_method_idx": {
+          "name": "paykit_payment_method_stripe_payment_method_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "paykit_payment_method_customer_id_paykit_customer_id_fk": {
+          "name": "paykit_payment_method_customer_id_paykit_customer_id_fk",
+          "tableFrom": "paykit_payment_method",
+          "tableTo": "paykit_customer",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paykit_product": {
+      "name": "paykit_product",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price_amount": {
+          "name": "price_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_currency": {
+          "name": "price_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_interval": {
+          "name": "price_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "paykit_product_id_version_unique": {
+          "name": "paykit_product_id_version_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_product_default_idx": {
+          "name": "paykit_product_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_product_stripe_product_idx": {
+          "name": "paykit_product_stripe_product_idx",
+          "columns": [
+            {
+              "expression": "stripe_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_product_stripe_price_idx": {
+          "name": "paykit_product_stripe_price_idx",
+          "columns": [
+            {
+              "expression": "stripe_price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paykit_product_feature": {
+      "name": "paykit_product_feature",
+      "schema": "",
+      "columns": {
+        "product_internal_id": {
+          "name": "product_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit": {
+          "name": "limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_interval": {
+          "name": "reset_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "paykit_product_feature_feature_idx": {
+          "name": "paykit_product_feature_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "paykit_product_feature_product_internal_id_paykit_product_internal_id_fk": {
+          "name": "paykit_product_feature_product_internal_id_paykit_product_internal_id_fk",
+          "tableFrom": "paykit_product_feature",
+          "tableTo": "paykit_product",
+          "columnsFrom": [
+            "product_internal_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "paykit_product_feature_feature_id_paykit_feature_id_fk": {
+          "name": "paykit_product_feature_feature_id_paykit_feature_id_fk",
+          "tableFrom": "paykit_product_feature",
+          "tableTo": "paykit_feature",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "paykit_product_feature_product_internal_id_feature_id_pk": {
+          "name": "paykit_product_feature_product_internal_id_feature_id_pk",
+          "columns": [
+            "product_internal_id",
+            "feature_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paykit_subscription": {
+      "name": "paykit_subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_internal_id": {
+          "name": "product_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_schedule_id": {
+          "name": "stripe_subscription_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled": {
+          "name": "canceled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start_at": {
+          "name": "current_period_start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end_at": {
+          "name": "current_period_end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_product_id": {
+          "name": "scheduled_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "paykit_subscription_customer_status_idx": {
+          "name": "paykit_subscription_customer_status_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_subscription_product_idx": {
+          "name": "paykit_subscription_product_idx",
+          "columns": [
+            {
+              "expression": "product_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_subscription_stripe_subscription_idx": {
+          "name": "paykit_subscription_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_subscription_stripe_schedule_idx": {
+          "name": "paykit_subscription_stripe_schedule_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "paykit_subscription_customer_id_paykit_customer_id_fk": {
+          "name": "paykit_subscription_customer_id_paykit_customer_id_fk",
+          "tableFrom": "paykit_subscription",
+          "tableTo": "paykit_customer",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "paykit_subscription_product_internal_id_paykit_product_internal_id_fk": {
+          "name": "paykit_subscription_product_internal_id_paykit_product_internal_id_fk",
+          "tableFrom": "paykit_subscription",
+          "tableTo": "paykit_product",
+          "columnsFrom": [
+            "product_internal_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paykit_webhook_event": {
+      "name": "paykit_webhook_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "paykit_webhook_event_stripe_event_id_unique": {
+          "name": "paykit_webhook_event_stripe_event_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paykit_webhook_event_stripe_status_idx": {
+          "name": "paykit_webhook_event_stripe_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/paykit/src/database/migrations/meta/_journal.json
+++ b/packages/paykit/src/database/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1780368513363,
       "tag": "0001_stripe_only_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1782216653893,
+      "tag": "0002_add-product-price-currency",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/paykit/src/database/schema.ts
+++ b/packages/paykit/src/database/schema.ts
@@ -85,6 +85,7 @@ export const product = pgTable(
     group: text("group").notNull().default(""),
     isDefault: boolean("is_default").notNull().default(false),
     priceAmount: integer("price_amount"),
+    priceCurrency: text("price_currency"),
     priceInterval: text("price_interval"),
     hash: text("hash"),
     stripeProductId: text("stripe_product_id"),

--- a/packages/paykit/src/index.ts
+++ b/packages/paykit/src/index.ts
@@ -26,6 +26,7 @@ export type {
   ReportResult,
 } from "./entitlement/entitlement.service";
 export { PAYKIT_STRIPE_API_VERSION } from "./stripe/stripe-provider";
+export type { StripeCurrency } from "./stripe/currency";
 export type { StripeOptions } from "./stripe/stripe-provider";
 export type {
   Customer,

--- a/packages/paykit/src/product/__tests__/product-sync.service.test.ts
+++ b/packages/paykit/src/product/__tests__/product-sync.service.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getLatestProductSnapshot: vi.fn(),
+  getProviderProduct: vi.fn(),
+  insertProductVersion: vi.fn(),
+  replaceProductFeatures: vi.fn(),
+  updateProductName: vi.fn(),
+  upsertFeature: vi.fn(),
+  upsertProviderProduct: vi.fn(),
+}));
+
+vi.mock("../product.service", () => mocks);
+
+import { dryRunSyncProducts, syncProducts } from "../product-sync.service";
+
+function createContext() {
+  const provider = {
+    id: "stripe",
+    syncProducts: vi.fn().mockResolvedValue({
+      results: [{ id: "pro", providerProduct: { priceId: "price_eur", productId: "prod_123" } }],
+    }),
+  };
+
+  return {
+    database: {},
+    products: {
+      features: [],
+      plans: [
+        {
+          group: "base",
+          hash: "hash_eur",
+          id: "pro",
+          includes: [],
+          isDefault: false,
+          name: "Pro",
+          priceAmount: 2900,
+          priceCurrency: "eur",
+          priceInterval: "month",
+          trialDays: null,
+        },
+      ],
+    },
+    provider,
+  };
+}
+
+const existingProduct = {
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  group: "base",
+  hash: "hash_usd",
+  id: "pro",
+  internalId: "prod_old",
+  isDefault: false,
+  name: "Pro",
+  priceAmount: 2900,
+  priceCurrency: "usd",
+  priceInterval: "month",
+  stripePriceId: "price_usd",
+  stripeProductId: "prod_123",
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+  version: 1,
+};
+
+describe("product-sync.service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getLatestProductSnapshot.mockResolvedValue({
+      features: [],
+      product: existingProduct,
+    });
+    mocks.getProviderProduct.mockResolvedValue({
+      priceId: "price_usd",
+      productId: "prod_123",
+    });
+    mocks.insertProductVersion.mockImplementation(async (_database, input) => ({
+      ...existingProduct,
+      ...input,
+      internalId: "prod_new",
+      stripePriceId: null,
+      stripeProductId: null,
+    }));
+  });
+
+  it("marks products as changed when currency changes", async () => {
+    const ctx = createContext();
+
+    await expect(dryRunSyncProducts(ctx as never)).resolves.toEqual([
+      { action: "created", id: "pro", version: 1 },
+    ]);
+  });
+
+  it("creates a new product version and syncs provider products with the new currency", async () => {
+    const ctx = createContext();
+
+    await expect(syncProducts(ctx as never)).resolves.toEqual([
+      { action: "created", id: "pro", version: 2 },
+    ]);
+
+    expect(mocks.insertProductVersion).toHaveBeenCalledWith(
+      ctx.database,
+      expect.objectContaining({
+        priceCurrency: "eur",
+        version: 2,
+      }),
+    );
+    expect(ctx.provider.syncProducts).toHaveBeenCalledWith({
+      products: [
+        {
+          existingProviderProduct: { productId: "prod_123" },
+          id: "pro",
+          name: "Pro",
+          priceAmount: 2900,
+          priceCurrency: "eur",
+          priceInterval: "month",
+        },
+      ],
+    });
+    expect(mocks.upsertProviderProduct).toHaveBeenCalledWith(ctx.database, {
+      productInternalId: "prod_new",
+      providerId: "stripe",
+      providerProduct: { priceId: "price_eur", productId: "prod_123" },
+    });
+  });
+});

--- a/packages/paykit/src/product/__tests__/product.service.test.ts
+++ b/packages/paykit/src/product/__tests__/product.service.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { PayKitDatabase } from "../../database";
+import type { StoredProduct } from "../../types/models";
+import type { NormalizedPlan } from "../../types/schema";
+import { getProductByPlan } from "../product.service";
+
+const now = new Date("2026-01-01T00:00:00Z");
+
+function createStoredProduct(overrides: Partial<StoredProduct> = {}): StoredProduct {
+  return {
+    createdAt: now,
+    group: "base",
+    hash: "old_hash",
+    id: "pro",
+    internalId: "prod_123",
+    isDefault: false,
+    name: "Pro",
+    priceAmount: 2900,
+    priceCurrency: "usd",
+    priceInterval: "month",
+    stripePriceId: "price_123",
+    stripeProductId: "prod_stripe_123",
+    updatedAt: now,
+    version: 1,
+    ...overrides,
+  };
+}
+
+function createPlan(overrides: Partial<NormalizedPlan> = {}): NormalizedPlan {
+  return {
+    group: "base",
+    hash: "new_hash",
+    id: "pro",
+    includes: [],
+    isDefault: false,
+    name: "Pro",
+    priceAmount: 2900,
+    priceCurrency: "usd",
+    priceInterval: "month",
+    trialDays: null,
+    ...overrides,
+  };
+}
+
+function createDatabase(storedProduct: StoredProduct) {
+  const productFindFirst = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(storedProduct);
+  const productFeatureFindMany = vi.fn().mockResolvedValue([]);
+
+  return {
+    database: {
+      query: {
+        product: {
+          findFirst: productFindFirst,
+        },
+        productFeature: {
+          findMany: productFeatureFindMany,
+        },
+      },
+    } as unknown as PayKitDatabase,
+    productFeatureFindMany,
+    productFindFirst,
+  };
+}
+
+describe("product.service", () => {
+  it("falls back to a semantically matching product when only the hash changed", async () => {
+    const storedProduct = createStoredProduct();
+    const { database } = createDatabase(storedProduct);
+
+    await expect(getProductByPlan(database, createPlan())).resolves.toEqual(storedProduct);
+  });
+
+  it("does not fall back when the stored product differs from the normalized plan", async () => {
+    const { database } = createDatabase(createStoredProduct({ priceAmount: 3900 }));
+
+    await expect(getProductByPlan(database, createPlan())).resolves.toBeNull();
+  });
+});

--- a/packages/paykit/src/product/product-sync.service.ts
+++ b/packages/paykit/src/product/product-sync.service.ts
@@ -57,9 +57,35 @@ function planChanged(
     existing.product.group !== next.group ||
     existing.product.isDefault !== next.isDefault ||
     (existing.product.priceAmount ?? null) !== next.priceAmount ||
+    (existing.product.priceCurrency ?? null) !== next.priceCurrency ||
     (existing.product.priceInterval ?? null) !== next.priceInterval ||
     featuresChanged(existing.features, next.includes)
   );
+}
+
+function priceChanged(
+  existing: Awaited<ReturnType<typeof getLatestProductSnapshot>>,
+  next: NormalizedPlan,
+): boolean {
+  if (!existing) {
+    return true;
+  }
+
+  return (
+    (existing.product.priceAmount ?? null) !== next.priceAmount ||
+    (existing.product.priceCurrency ?? null) !== next.priceCurrency ||
+    (existing.product.priceInterval ?? null) !== next.priceInterval
+  );
+}
+
+function withoutExistingPrice(
+  providerProduct: Record<string, string> | null,
+): Record<string, string> | null {
+  if (!providerProduct?.productId) {
+    return null;
+  }
+
+  return { productId: providerProduct.productId };
 }
 
 export async function dryRunSyncProducts(ctx: PayKitContext): Promise<SyncProductResult[]> {
@@ -99,6 +125,7 @@ export async function syncProducts(ctx: PayKitContext): Promise<SyncProductResul
     id: string;
     name: string;
     priceAmount: number;
+    priceCurrency: string;
     priceInterval: string;
     existingProviderProduct: Record<string, string> | null;
     storedProductInternalId: string;
@@ -112,6 +139,7 @@ export async function syncProducts(ctx: PayKitContext): Promise<SyncProductResul
 
     let storedProduct = existing?.product ?? null;
     let action: SyncProductResult["action"] = "unchanged";
+    let providerProductForSync = existingProviderProduct;
 
     if (!existing) {
       storedProduct = await insertProductVersion(ctx.database, {
@@ -121,6 +149,7 @@ export async function syncProducts(ctx: PayKitContext): Promise<SyncProductResul
         isDefault: plan.isDefault,
         name: plan.name,
         priceAmount: plan.priceAmount,
+        priceCurrency: plan.priceCurrency,
         priceInterval: plan.priceInterval,
         version: 1,
       });
@@ -130,6 +159,9 @@ export async function syncProducts(ctx: PayKitContext): Promise<SyncProductResul
       });
       action = "created";
     } else if (planChanged(existing, plan)) {
+      if (priceChanged(existing, plan)) {
+        providerProductForSync = withoutExistingPrice(existingProviderProduct);
+      }
       storedProduct = await insertProductVersion(ctx.database, {
         group: plan.group,
         hash: plan.hash,
@@ -137,6 +169,7 @@ export async function syncProducts(ctx: PayKitContext): Promise<SyncProductResul
         isDefault: plan.isDefault,
         name: plan.name,
         priceAmount: plan.priceAmount,
+        priceCurrency: plan.priceCurrency,
         priceInterval: plan.priceInterval,
         version: existing.product.version + 1,
       });
@@ -159,12 +192,17 @@ export async function syncProducts(ctx: PayKitContext): Promise<SyncProductResul
       );
     }
 
-    if (storedProduct.priceAmount !== null && storedProduct.priceInterval !== null) {
+    if (
+      storedProduct.priceAmount !== null &&
+      storedProduct.priceCurrency !== null &&
+      storedProduct.priceInterval !== null
+    ) {
       paidPlansToSync.push({
-        existingProviderProduct: existingProviderProduct ?? null,
+        existingProviderProduct: providerProductForSync ?? null,
         id: plan.id,
         name: plan.name,
         priceAmount: storedProduct.priceAmount,
+        priceCurrency: storedProduct.priceCurrency,
         priceInterval: storedProduct.priceInterval,
         storedProductInternalId: storedProduct.internalId,
       });
@@ -184,6 +222,7 @@ export async function syncProducts(ctx: PayKitContext): Promise<SyncProductResul
         id: p.id,
         name: p.name,
         priceAmount: p.priceAmount,
+        priceCurrency: p.priceCurrency,
         priceInterval: p.priceInterval,
       })),
     });

--- a/packages/paykit/src/product/product.service.ts
+++ b/packages/paykit/src/product/product.service.ts
@@ -5,7 +5,7 @@ import { generateId } from "../core/utils";
 import type { PayKitDatabase } from "../database";
 import { feature, product, productFeature } from "../database/schema";
 import type { StoredFeature, StoredProduct, StoredProductFeature } from "../types/models";
-import type { NormalizedFeature, NormalizedPlanFeature } from "../types/schema";
+import type { NormalizedFeature, NormalizedPlan, NormalizedPlanFeature } from "../types/schema";
 
 export interface StoredProductSnapshot {
   features: readonly StoredProductFeature[];
@@ -107,6 +107,62 @@ export async function getProductByHash(
   });
 
   return result ?? null;
+}
+
+function serializeFeatureConfig(config: Record<string, unknown> | null): string {
+  return JSON.stringify(config ?? null);
+}
+
+function productFeaturesMatch(
+  existing: readonly StoredProductFeature[],
+  next: readonly NormalizedPlanFeature[],
+): boolean {
+  if (existing.length !== next.length) {
+    return false;
+  }
+
+  return existing.every((storedFeature, index) => {
+    const nextFeature = next[index];
+    return (
+      nextFeature != null &&
+      storedFeature.featureId === nextFeature.id &&
+      storedFeature.limit === nextFeature.limit &&
+      storedFeature.resetInterval === nextFeature.resetInterval &&
+      serializeFeatureConfig(storedFeature.config) === serializeFeatureConfig(nextFeature.config)
+    );
+  });
+}
+
+function productSnapshotMatchesPlan(
+  snapshot: StoredProductSnapshot,
+  plan: NormalizedPlan,
+): boolean {
+  return (
+    snapshot.product.group === plan.group &&
+    snapshot.product.isDefault === plan.isDefault &&
+    (snapshot.product.priceAmount ?? null) === plan.priceAmount &&
+    (snapshot.product.priceCurrency ?? null) === plan.priceCurrency &&
+    (snapshot.product.priceInterval ?? null) === plan.priceInterval &&
+    productFeaturesMatch(snapshot.features, plan.includes)
+  );
+}
+
+/** Finds the stored product for a normalized plan, including old hash-compatible rows. */
+export async function getProductByPlan(
+  database: PayKitDatabase,
+  plan: NormalizedPlan,
+): Promise<StoredProduct | null> {
+  const exact = await getProductByHash(database, plan.id, plan.hash);
+  if (exact) {
+    return exact;
+  }
+
+  const latest = await getLatestProductSnapshot(database, plan.id);
+  if (!latest || !productSnapshotMatchesPlan(latest, plan)) {
+    return null;
+  }
+
+  return latest.product;
 }
 
 export async function getProductByInternalId(

--- a/packages/paykit/src/product/product.service.ts
+++ b/packages/paykit/src/product/product.service.ts
@@ -146,6 +146,7 @@ export async function insertProductVersion(
     isDefault: boolean;
     name: string;
     priceAmount: number | null;
+    priceCurrency: string | null;
     priceInterval: string | null;
     version: number;
   },
@@ -161,6 +162,7 @@ export async function insertProductVersion(
     isDefault: input.isDefault,
     name: input.name,
     priceAmount: input.priceAmount,
+    priceCurrency: input.priceCurrency,
     priceInterval: input.priceInterval,
     updatedAt: now,
     version: input.version,
@@ -175,6 +177,7 @@ export async function insertProductVersion(
     isDefault: input.isDefault,
     name: input.name,
     priceAmount: input.priceAmount,
+    priceCurrency: input.priceCurrency,
     priceInterval: input.priceInterval,
     stripePriceId: null,
     stripeProductId: null,

--- a/packages/paykit/src/providers/provider.ts
+++ b/packages/paykit/src/providers/provider.ts
@@ -157,6 +157,7 @@ export interface PaymentProvider {
       id: string;
       name: string;
       priceAmount: number;
+      priceCurrency: string;
       priceInterval?: string | null;
       existingProviderProduct?: Record<string, string> | null;
     }>;

--- a/packages/paykit/src/stripe/__tests__/stripe-provider.test.ts
+++ b/packages/paykit/src/stripe/__tests__/stripe-provider.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createStripeProvider } from "../stripe-provider";
+
+function createStripeClientMock() {
+  return {
+    invoices: {
+      addLines: vi.fn().mockResolvedValue({}),
+      create: vi.fn().mockResolvedValue({ id: "in_123" }),
+      finalizeInvoice: vi.fn().mockResolvedValue({
+        currency: "eur",
+        id: "in_123",
+        status: "open",
+        total: 2900,
+      }),
+    },
+    prices: {
+      create: vi.fn().mockResolvedValue({ id: "price_123" }),
+    },
+    products: {
+      create: vi.fn().mockResolvedValue({ id: "prod_123" }),
+    },
+  };
+}
+
+describe("stripe-provider", () => {
+  it("creates Stripe prices with the product currency", async () => {
+    const client = createStripeClientMock();
+    const provider = createStripeProvider(client as never, {
+      currency: "usd",
+      secretKey: "sk_test_123",
+    });
+
+    await provider.syncProducts({
+      products: [
+        {
+          existingProviderProduct: null,
+          id: "pro",
+          name: "Pro",
+          priceAmount: 2900,
+          priceCurrency: "eur",
+          priceInterval: "month",
+        },
+      ],
+    });
+
+    expect(client.prices.create).toHaveBeenCalledWith({
+      currency: "eur",
+      product: "prod_123",
+      recurring: { interval: "month" },
+      unit_amount: 2900,
+    });
+  });
+
+  it("creates invoices with the configured currency", async () => {
+    const client = createStripeClientMock();
+    const provider = createStripeProvider(client as never, {
+      currency: "eur",
+      secretKey: "sk_test_123",
+    });
+
+    await provider.createInvoice({
+      lines: [],
+      providerCustomerId: "cus_123",
+    });
+
+    expect(client.invoices.create).toHaveBeenCalledWith({
+      auto_advance: true,
+      collection_method: "charge_automatically",
+      currency: "eur",
+      customer: "cus_123",
+    });
+  });
+});

--- a/packages/paykit/src/stripe/currency.ts
+++ b/packages/paykit/src/stripe/currency.ts
@@ -1,0 +1,13 @@
+export const DEFAULT_STRIPE_CURRENCY = "usd";
+
+export const SUPPORTED_STRIPE_CURRENCIES = ["usd", "eur"] as const;
+
+export type StripeCurrency = (typeof SUPPORTED_STRIPE_CURRENCIES)[number];
+
+export function getStripeCurrency(options: { currency?: StripeCurrency }): StripeCurrency {
+  return options.currency ?? DEFAULT_STRIPE_CURRENCY;
+}
+
+export function isSupportedStripeCurrency(value: string): value is StripeCurrency {
+  return SUPPORTED_STRIPE_CURRENCIES.includes(value as StripeCurrency);
+}

--- a/packages/paykit/src/stripe/stripe-provider.ts
+++ b/packages/paykit/src/stripe/stripe-provider.ts
@@ -3,6 +3,7 @@ import StripeSdk from "stripe";
 import { PayKitError, PAYKIT_ERROR_CODES } from "../core/errors";
 import type { PaymentProvider, ProviderTestClock } from "../providers/provider";
 import type { NormalizedWebhookEvent } from "../types/events";
+import { DEFAULT_STRIPE_CURRENCY, getStripeCurrency, type StripeCurrency } from "./currency";
 
 /**
  * Stripe API version PayKit is tested against. Users can override via
@@ -27,6 +28,11 @@ const STRIPE_WEBHOOK_EVENTS: StripeSdk.WebhookEndpointCreateParams.EnabledEvent[
 export interface StripeOptions {
   secretKey: string;
   webhookSecret: string;
+  /**
+   * Currency used for new Stripe prices and PayKit-created invoices.
+   * @default "usd"
+   */
+  currency?: StripeCurrency;
   /** Override the Stripe API version (e.g. for preview features). */
   apiVersion?: string;
   /** Enable Stripe Managed Payments (requires a preview API version). */
@@ -586,7 +592,7 @@ export function createStripeProvider(
   client: StripeSdk,
   options: StripeAdapterOptions,
 ): PaymentProvider {
-  const currency = "usd";
+  const currency = getStripeCurrency(options);
 
   return {
     id: "stripe",
@@ -927,7 +933,7 @@ export function createStripeProvider(
           }
 
           const priceParams: StripeSdk.PriceCreateParams = {
-            currency,
+            currency: product.priceCurrency,
             product: productId,
             unit_amount: product.priceAmount,
           };
@@ -1078,6 +1084,7 @@ export function createStripeProvider(
 }
 
 export function createStripeAdapter(options: StripeAdapterOptions): PaymentProvider {
+  const optionsWithDefaults = { ...options, currency: options.currency ?? DEFAULT_STRIPE_CURRENCY };
   const apiVersion = options.apiVersion ?? PAYKIT_STRIPE_API_VERSION;
   if (options.managedPayments) {
     if (!apiVersion.endsWith(".preview") || apiVersion < STRIPE_MANAGED_PAYMENTS_MIN_VERSION) {
@@ -1093,5 +1100,5 @@ export function createStripeAdapter(options: StripeAdapterOptions): PaymentProvi
     maxNetworkRetries: 3,
   });
 
-  return createStripeProvider(client, options);
+  return createStripeProvider(client, optionsWithDefaults);
 }

--- a/packages/paykit/src/subscription/subscription.service.ts
+++ b/packages/paykit/src/subscription/subscription.service.ts
@@ -13,7 +13,7 @@ import { upsertInvoiceRecord } from "../invoice/invoice.service";
 import { getDefaultPaymentMethod } from "../payment-method/payment-method.service";
 import {
   getDefaultProductInGroup,
-  getProductByHash,
+  getProductByPlan,
   getProductByInternalId,
   getProductByProviderData,
   getProductFeatures,
@@ -103,7 +103,7 @@ export async function loadSubscribeContext(ctx: PayKitContext, input: SubscribeI
   const matchingProduct = input.productInternalId
     ? await getProductByInternalId(ctx.database, input.productInternalId)
     : normalizedPlan
-      ? await getProductByHash(ctx.database, input.planId, normalizedPlan.hash)
+      ? await getProductByPlan(ctx.database, normalizedPlan)
       : null;
   const storedPlan = matchingProduct ? withProviderInfo(matchingProduct, providerId) : null;
 
@@ -245,11 +245,11 @@ async function cancelExistingProviderSubscriptionForCheckout(
     return;
   }
 
-  if (!completion.subCtx.isUpgrade) {
+  if (!completion.subCtx.isUpgrade && !completion.subCtx.isPaidCurrencyChange) {
     throw PayKitError.from(
       "BAD_REQUEST",
       PAYKIT_ERROR_CODES.PROVIDER_WEBHOOK_INVALID,
-      `Checkout completion is only valid for new paid subscriptions or upgrades to "${completion.subCtx.storedPlan.id}"`,
+      `Checkout completion is only valid for new paid subscriptions, upgrades, or cross-currency changes to "${completion.subCtx.storedPlan.id}"`,
     );
   }
 

--- a/packages/paykit/src/subscription/subscription.service.ts
+++ b/packages/paykit/src/subscription/subscription.service.ts
@@ -58,6 +58,9 @@ export async function subscribeToPlan(
     } else if (subCtx.isFreeTarget) {
       // Switching from paid to free always happens at period end.
       result = await handleCancelToFree(ctx, subCtx);
+    } else if (subCtx.isPaidCurrencyChange) {
+      // Cross-currency paid changes need a new checkout-backed subscription.
+      result = await createCheckoutSubscribe(ctx, subCtx);
     } else if (!subCtx.isUpgrade) {
       // Paid downgrades stay active now and schedule the cheaper plan for later.
       result = await handleScheduledDowngrade(ctx, subCtx);
@@ -148,9 +151,15 @@ export async function loadSubscribeContext(ctx: PayKitContext, input: SubscribeI
 
   const activeAmount = activeSubscription?.priceAmount ?? 0;
   const targetAmount = storedPlan.priceAmount ?? 0;
+  const isPaidCurrencyChange =
+    activeSubscription != null &&
+    activeSubscription.priceCurrency !== null &&
+    storedPlan.priceCurrency !== null &&
+    activeSubscription.priceCurrency !== storedPlan.priceCurrency;
   const isUpgrade =
     activeSubscription != null &&
     hasProviderSubscription(activeSubscription) &&
+    !isPaidCurrencyChange &&
     targetAmount > activeAmount;
 
   const planFeatures = normalizedPlan
@@ -163,6 +172,7 @@ export async function loadSubscribeContext(ctx: PayKitContext, input: SubscribeI
     customerId: input.customerId,
     isFreeTarget,
     isPaidTarget,
+    isPaidCurrencyChange,
     isUpgrade,
     normalizedPlan,
     planFeatures,
@@ -1236,6 +1246,7 @@ function mapJoinRowToSubscriptionWithCatalog(row: {
     planIsDefault: row.product.isDefault,
     planName: row.product.name,
     priceAmount: row.product.priceAmount,
+    priceCurrency: row.product.priceCurrency,
     priceInterval: row.product.priceInterval,
     providerProduct: stripeProduct,
   };

--- a/packages/paykit/src/subscription/subscription.types.ts
+++ b/packages/paykit/src/subscription/subscription.types.ts
@@ -39,6 +39,7 @@ export interface SubscriptionWithCatalog extends StoredSubscription {
   planIsDefault: boolean;
   planName: string;
   priceAmount: number | null;
+  priceCurrency: string | null;
   priceInterval: string | null;
   providerProduct: Record<string, string> | null;
 }

--- a/packages/paykit/src/types/__tests__/schema.test.ts
+++ b/packages/paykit/src/types/__tests__/schema.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeSchema, plan } from "../schema";
+
+describe("types/schema", () => {
+  it("stores configured currency on paid normalized plans", () => {
+    const products = [
+      plan({
+        group: "base",
+        id: "pro",
+        price: { amount: 29, interval: "month" },
+      }),
+    ];
+
+    const schema = normalizeSchema(products, { priceCurrency: "eur" });
+
+    expect(schema.planMap.get("pro")?.priceCurrency).toBe("eur");
+  });
+
+  it("changes plan hash when configured currency changes", () => {
+    const products = [
+      plan({
+        group: "base",
+        id: "pro",
+        price: { amount: 29, interval: "month" },
+      }),
+    ];
+
+    const usd = normalizeSchema(products, { priceCurrency: "usd" });
+    const eur = normalizeSchema(products, { priceCurrency: "eur" });
+
+    expect(usd.planMap.get("pro")?.hash).not.toBe(eur.planMap.get("pro")?.hash);
+  });
+
+  it("keeps free normalized plans currencyless", () => {
+    const products = [
+      plan({
+        default: true,
+        group: "base",
+        id: "free",
+      }),
+    ];
+
+    const schema = normalizeSchema(products, { priceCurrency: "eur" });
+
+    expect(schema.planMap.get("free")?.priceCurrency).toBeNull();
+  });
+});

--- a/packages/paykit/src/types/schema.ts
+++ b/packages/paykit/src/types/schema.ts
@@ -132,6 +132,7 @@ export interface NormalizedPlan {
   isDefault: boolean;
   name: string;
   priceAmount: number | null;
+  priceCurrency: string | null;
   priceInterval: PriceInterval | null;
   trialDays: number | null;
 }
@@ -325,6 +326,7 @@ export function computePlanHash(plan: Omit<NormalizedPlan, "hash">): string {
     group: plan.group,
     isDefault: plan.isDefault,
     priceAmount: plan.priceAmount,
+    priceCurrency: plan.priceCurrency,
     priceInterval: plan.priceInterval,
     features: plan.includes.map((f) => ({
       id: f.id,
@@ -336,7 +338,10 @@ export function computePlanHash(plan: Omit<NormalizedPlan, "hash">): string {
   return createHash("sha256").update(payload).digest("hex").slice(0, 16);
 }
 
-export function normalizeSchema(products: PayKitProductsModule | undefined): NormalizedSchema {
+export function normalizeSchema(
+  products: PayKitProductsModule | undefined,
+  input?: { priceCurrency?: string },
+): NormalizedSchema {
   if (!products) {
     return {
       features: [],
@@ -424,6 +429,7 @@ export function normalizeSchema(products: PayKitProductsModule | undefined): Nor
       isDefault,
       name: exportedPlan.name ?? deriveNameFromId(exportedPlan.id),
       priceAmount: exportedPlan.price ? Math.round(exportedPlan.price.amount * 100) : null,
+      priceCurrency: exportedPlan.price ? (input?.priceCurrency ?? "usd") : null,
       priceInterval: exportedPlan.price?.interval ?? null,
       trialDays: null,
     };

--- a/packages/paykit/src/types/schema.ts
+++ b/packages/paykit/src/types/schema.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 
 import * as z from "zod";
 
+import { DEFAULT_STRIPE_CURRENCY } from "../stripe/currency";
+
 const payKitFeatureSymbol = Symbol.for("paykit.feature");
 const payKitFeatureIncludeSymbol = Symbol.for("paykit.feature_include");
 const payKitPlanSymbol = Symbol.for("paykit.plan");
@@ -429,7 +431,7 @@ export function normalizeSchema(
       isDefault,
       name: exportedPlan.name ?? deriveNameFromId(exportedPlan.id),
       priceAmount: exportedPlan.price ? Math.round(exportedPlan.price.amount * 100) : null,
-      priceCurrency: exportedPlan.price ? (input?.priceCurrency ?? "usd") : null,
+      priceCurrency: exportedPlan.price ? (input?.priceCurrency ?? DEFAULT_STRIPE_CURRENCY) : null,
       priceInterval: exportedPlan.price?.interval ?? null,
       trialDays: null,
     };


### PR DESCRIPTION
## Summary
- add global Stripe currency support for `usd` and `eur`
- persist product price currency and backfill existing paid products to `usd`
- create a new Stripe Price when amount, interval, or currency changes
- add focused unit coverage and EUR product-sync E2E coverage

## Tests
- pnpm --filter paykitjs typecheck
- pnpm test:unit
- pnpm --filter paykitjs build
- pnpm format:check
- pnpm lint
- PAYKIT_ALLOW_UNSIGNED_PAYLOADS=1 E2E_STRIPE_WHSEC=whsec_dummy pnpm --filter e2e exec vitest run --project=cli cli/push.test.ts
- full Stripe E2E earlier: 19 files / 21 tests passed

No release/changset in this PR; release will happen separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds global Stripe currency support for `usd` and `eur`. Products now store `priceCurrency`, plan hashes include currency, syncing/subscriptions handle currency changes, and the CLI formats EUR prices.

- **New Features**
  - Add `stripe.currency` option (`usd` or `eur`, default `usd`) with strict lowercase 3-letter validation.
  - Normalize paid plans with the configured currency and include it in plan hashes; persist `priceCurrency` on products and backfill existing paid plans to `usd`.
  - Create a new Stripe Price when amount, interval, or currency changes; provider uses the plan’s currency for price creation and the configured currency for invoices.
  - Handle cross-currency paid plan changes by creating a new checkout-backed subscription.
  - Improve CLI `formatPrice` to localize currency and support EUR.
  - Resolve stored products by semantic plan match when only the hash changed to avoid unnecessary churn.

- **Migration**
  - Run DB migration `0002_add-product-price-currency`.
  - Re-run product sync (e.g., `paykitjs push`) to create currency-specific Stripe Prices (set `stripe.currency` to `eur` if needed, then push).

<sup>Written for commit 310f16ec03e6c8b12771d73cecbf65814a343a24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getpaykit/paykit/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-currency product pricing with support for USD and EUR.
  * Plans now carry a currency setting where applicable, affecting hashing and product matching.
  * Switching between paid plans of different currencies now uses checkout flow.
* **Improvements**
  * Price display uses locale-aware currency formatting.
  * Product sync now tracks and syncs the plan’s currency.
* **Validation**
  * Stripe currency input is now strictly validated (lowercase 3-letter, supported set).
* **Database**
  * Added `price_currency` to products and initialized existing records.
* **Tests**
  * Expanded formatting, schema, and end-to-end sync coverage (including EUR).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->