### PR TITLE
Add subscription quantity support

### DIFF
--- a/packages/paykit/src/providers/provider.ts
+++ b/packages/paykit/src/providers/provider.ts
@@ -64,6 +64,7 @@ export interface ProviderSubscription {
   endedAt?: Date | null;
   providerSubscriptionId: string;
   providerSubscriptionScheduleId?: string | null;
+  quantity?: number;
   status: string;
 }
 
@@ -111,16 +112,19 @@ export interface PaymentProvider {
     successUrl: string;
     cancelUrl?: string;
     metadata?: Record<string, string>;
+    quantity: number;
   }): Promise<{ paymentUrl: string; providerCheckoutSessionId: string }>;
 
   createSubscription(data: {
     providerCustomerId: string;
     providerProduct: Record<string, string>;
+    quantity: number;
   }): Promise<ProviderSubscriptionResult>;
 
   updateSubscription(data: {
     providerProduct: Record<string, string>;
     providerSubscriptionId: string;
+    quantity: number;
   }): Promise<ProviderSubscriptionResult>;
 
   createInvoice(data: {
@@ -133,6 +137,7 @@ export interface PaymentProvider {
     providerProduct?: Record<string, string> | null;
     providerSubscriptionScheduleId?: string | null;
     providerSubscriptionId: string;
+    quantity: number;
   }): Promise<ProviderSubscriptionResult>;
 
   cancelSubscription(data: {

--- a/packages/paykit/src/stripe/__tests__/stripe-provider.test.ts
+++ b/packages/paykit/src/stripe/__tests__/stripe-provider.test.ts
@@ -2,8 +2,37 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createStripeProvider } from "../stripe-provider";
 
+function createStripeSubscription(quantity = 1) {
+  return {
+    cancel_at: null,
+    cancel_at_period_end: false,
+    canceled_at: null,
+    ended_at: null,
+    id: "sub_123",
+    items: {
+      data: [
+        {
+          current_period_end: 1_750_000_000,
+          current_period_start: 1_700_000_000,
+          id: "si_123",
+          price: { id: "price_123", product: "prod_123" },
+          quantity,
+        },
+      ],
+    },
+    latest_invoice: null,
+    schedule: null,
+    status: "active",
+  };
+}
+
 function createStripeClientMock() {
   return {
+    checkout: {
+      sessions: {
+        create: vi.fn().mockResolvedValue({ id: "cs_123", url: "https://checkout.test/session" }),
+      },
+    },
     invoices: {
       addLines: vi.fn().mockResolvedValue({}),
       create: vi.fn().mockResolvedValue({ id: "in_123" }),
@@ -19,6 +48,16 @@ function createStripeClientMock() {
     },
     products: {
       create: vi.fn().mockResolvedValue({ id: "prod_123" }),
+    },
+    subscriptions: {
+      create: vi.fn().mockResolvedValue(createStripeSubscription(3)),
+      retrieve: vi.fn().mockResolvedValue(createStripeSubscription(1)),
+      update: vi.fn().mockResolvedValue(createStripeSubscription(4)),
+    },
+    subscriptionSchedules: {
+      create: vi.fn().mockResolvedValue({ id: "sched_123", phases: [] }),
+      retrieve: vi.fn().mockResolvedValue({ id: "sched_123", phases: [] }),
+      update: vi.fn().mockResolvedValue({ id: "sched_123", phases: [] }),
     },
   };
 }
@@ -70,5 +109,101 @@ describe("stripe-provider", () => {
       currency: "eur",
       customer: "cus_123",
     });
+  });
+
+  it("passes quantity to Stripe Checkout subscription line items", async () => {
+    const client = createStripeClientMock();
+    const provider = createStripeProvider(client as never, {
+      currency: "eur",
+      secretKey: "sk_test_123",
+    });
+
+    await provider.createSubscriptionCheckout({
+      providerCustomerId: "cus_123",
+      providerProduct: { priceId: "price_123", productId: "prod_123" },
+      quantity: 3,
+      successUrl: "https://app.test/success",
+    });
+
+    expect(client.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [{ price: "price_123", quantity: 3 }],
+      }),
+    );
+  });
+
+  it("passes quantity to direct Stripe subscription creation", async () => {
+    const client = createStripeClientMock();
+    const provider = createStripeProvider(client as never, {
+      currency: "eur",
+      secretKey: "sk_test_123",
+    });
+
+    const result = await provider.createSubscription({
+      providerCustomerId: "cus_123",
+      providerProduct: { priceId: "price_123", productId: "prod_123" },
+      quantity: 3,
+    });
+
+    expect(client.subscriptions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [{ price: "price_123", quantity: 3 }],
+      }),
+    );
+    expect(result.subscription?.quantity).toBe(3);
+  });
+
+  it("passes quantity when updating a Stripe subscription", async () => {
+    const client = createStripeClientMock();
+    const provider = createStripeProvider(client as never, {
+      currency: "eur",
+      secretKey: "sk_test_123",
+    });
+
+    const result = await provider.updateSubscription({
+      providerProduct: { priceId: "price_456", productId: "prod_456" },
+      providerSubscriptionId: "sub_123",
+      quantity: 4,
+    });
+
+    expect(client.subscriptions.update).toHaveBeenCalledWith(
+      "sub_123",
+      expect.objectContaining({
+        items: [{ id: "si_123", price: "price_456", quantity: 4 }],
+      }),
+    );
+    expect(result.subscription?.quantity).toBe(4);
+  });
+
+  it("preserves current quantity and applies target quantity for scheduled changes", async () => {
+    const client = createStripeClientMock();
+    client.subscriptions.retrieve
+      .mockResolvedValueOnce(createStripeSubscription(5))
+      .mockResolvedValueOnce(createStripeSubscription(2));
+    const provider = createStripeProvider(client as never, {
+      currency: "eur",
+      secretKey: "sk_test_123",
+    });
+
+    const result = await provider.scheduleSubscriptionChange({
+      providerProduct: { priceId: "price_456", productId: "prod_456" },
+      providerSubscriptionId: "sub_123",
+      quantity: 2,
+    });
+
+    expect(client.subscriptionSchedules.update).toHaveBeenCalledWith(
+      "sched_123",
+      expect.objectContaining({
+        phases: [
+          expect.objectContaining({
+            items: [{ price: "price_123", quantity: 5 }],
+          }),
+          expect.objectContaining({
+            items: [{ price: "price_456", quantity: 2 }],
+          }),
+        ],
+      }),
+    );
+    expect(result.subscription?.quantity).toBe(2);
   });
 });

--- a/packages/paykit/src/stripe/stripe-provider.ts
+++ b/packages/paykit/src/stripe/stripe-provider.ts
@@ -189,6 +189,7 @@ function normalizeStripeSubscription(subscription: StripeSubscriptionWithExtras)
       (typeof subscription.schedule === "string"
         ? subscription.schedule
         : subscription.schedule?.id) ?? null,
+    quantity: firstItem?.quantity ?? 1,
     status: subscription.status,
   };
 }
@@ -686,7 +687,7 @@ export function createStripeProvider(
         cancel_url: data.cancelUrl ?? data.successUrl,
         client_reference_id: data.providerCustomerId,
         customer: data.providerCustomerId,
-        line_items: [{ price: data.providerProduct.priceId, quantity: 1 }],
+        line_items: [{ price: data.providerProduct.priceId, quantity: data.quantity }],
         metadata: data.metadata,
         mode: "subscription",
         success_url: data.successUrl,
@@ -709,7 +710,7 @@ export function createStripeProvider(
     async createSubscription(data) {
       const createParams: StripeSdk.SubscriptionCreateParams = {
         customer: data.providerCustomerId,
-        items: [{ price: data.providerProduct.priceId }],
+        items: [{ price: data.providerProduct.priceId, quantity: data.quantity }],
         payment_behavior: "default_incomplete",
         expand: ["latest_invoice.payment_intent"],
       };
@@ -753,6 +754,7 @@ export function createStripeProvider(
           {
             id: currentItem.id,
             price: data.providerProduct.priceId,
+            quantity: data.quantity,
           },
         ],
         payment_behavior: "pending_if_incomplete",
@@ -794,10 +796,12 @@ export function createStripeProvider(
         );
       }
 
-      const currentItems = currentSub.items.data.map((item: { price: { id: string } }) => ({
-        price: item.price.id,
-        quantity: 1,
-      }));
+      const currentItems = currentSub.items.data.map(
+        (item: { price: { id: string }; quantity?: number | null }) => ({
+          price: item.price.id,
+          quantity: item.quantity ?? 1,
+        }),
+      );
 
       let schedule: StripeSdk.SubscriptionSchedule;
       if (data.providerSubscriptionScheduleId) {
@@ -827,7 +831,7 @@ export function createStripeProvider(
             end_date: periodEndSeconds,
           },
           {
-            items: [{ price: data.providerProduct.priceId, quantity: 1 }],
+            items: [{ price: data.providerProduct.priceId, quantity: data.quantity }],
             start_date: periodEndSeconds,
           },
         ],

--- a/packages/paykit/src/subscription/__tests__/subscription.service.test.ts
+++ b/packages/paykit/src/subscription/__tests__/subscription.service.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { PayKitDatabase } from "../../database";
+import {
+  syncSubscriptionBillingState,
+  syncSubscriptionFromProvider,
+} from "../subscription.service";
+
+function createUpdateChain() {
+  const where = vi.fn().mockResolvedValue(undefined);
+  const set = vi.fn().mockReturnValue({ where });
+  return { set, where };
+}
+
+describe("subscription/service", () => {
+  it("syncs provider subscription quantity into the local subscription", async () => {
+    const update = createUpdateChain();
+    const database = {
+      update: vi.fn().mockReturnValue({ set: update.set }),
+    } as unknown as PayKitDatabase;
+
+    await syncSubscriptionFromProvider(database, {
+      providerSubscription: {
+        cancelAtPeriodEnd: false,
+        providerSubscriptionId: "sub_123",
+        quantity: 3,
+        status: "active",
+      },
+      subscriptionId: "sub_local_123",
+    });
+
+    expect(update.set).toHaveBeenCalledWith(expect.objectContaining({ quantity: 3 }));
+  });
+
+  it("syncs explicit billing state quantity without resetting existing quantity", async () => {
+    const update = createUpdateChain();
+    const database = {
+      query: {
+        subscription: {
+          findFirst: vi.fn().mockResolvedValue({
+            currentPeriodEndAt: null,
+            currentPeriodStartAt: null,
+            id: "sub_local_123",
+            quantity: 1,
+            startedAt: null,
+            status: "active",
+            stripeSubscriptionId: "sub_123",
+            stripeSubscriptionScheduleId: null,
+          }),
+        },
+      },
+      update: vi.fn().mockReturnValue({ set: update.set }),
+    } as unknown as PayKitDatabase;
+
+    await syncSubscriptionBillingState(database, {
+      quantity: 4,
+      subscriptionId: "sub_local_123",
+    });
+
+    expect(update.set).toHaveBeenCalledWith(expect.objectContaining({ quantity: 4 }));
+  });
+});

--- a/packages/paykit/src/subscription/__tests__/subscription.types.test.ts
+++ b/packages/paykit/src/subscription/__tests__/subscription.types.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { subscribeBodySchema } from "../subscription.types";
+
+const validSubscribeBody = {
+  planId: "restaurant-live",
+  successUrl: "https://app.example.com/billing/success",
+};
+
+describe("subscribeBodySchema", () => {
+  it("accepts missing quantity for the default quantity path", () => {
+    expect(subscribeBodySchema.safeParse(validSubscribeBody).success).toBe(true);
+  });
+
+  it("accepts a positive integer quantity", () => {
+    expect(subscribeBodySchema.safeParse({ ...validSubscribeBody, quantity: 3 }).success).toBe(
+      true,
+    );
+  });
+
+  it("rejects zero, negative, and decimal quantities", () => {
+    expect(subscribeBodySchema.safeParse({ ...validSubscribeBody, quantity: 0 }).success).toBe(
+      false,
+    );
+    expect(subscribeBodySchema.safeParse({ ...validSubscribeBody, quantity: -1 }).success).toBe(
+      false,
+    );
+    expect(subscribeBodySchema.safeParse({ ...validSubscribeBody, quantity: 1.5 }).success).toBe(
+      false,
+    );
+  });
+});

--- a/packages/paykit/src/subscription/subscription.api.ts
+++ b/packages/paykit/src/subscription/subscription.api.ts
@@ -18,6 +18,7 @@ export const subscribe = definePayKitMethod(
       customerId: ctx.customer.id,
       forceCheckout: ctx.input.forceCheckout,
       planId: ctx.input.planId,
+      quantity: ctx.input.quantity,
       successUrl: ctx.input.successUrl,
       cancelUrl: ctx.input.cancelUrl,
     });

--- a/packages/paykit/src/subscription/subscription.service.ts
+++ b/packages/paykit/src/subscription/subscription.service.ts
@@ -46,7 +46,10 @@ export async function subscribeToPlan(
     const subCtx = await loadSubscribeContext(ctx, input);
 
     let result: SubscribeResult;
-    if (isSamePlan(subCtx)) {
+    if (isSamePlan(subCtx) && !isSameQuantity(subCtx)) {
+      // Same plan with a different quantity updates the current provider subscription in place.
+      result = await handleQuantityChange(ctx, subCtx);
+    } else if (isSamePlan(subCtx)) {
       // Same plan means either a noop or resuming a pending cancellation.
       result = await handleSamePlanSubscribe(ctx, subCtx);
     } else if (!subCtx.activeSubscription) {
@@ -99,6 +102,7 @@ async function resolveStoredPlanFeatures(
 
 export async function loadSubscribeContext(ctx: PayKitContext, input: SubscribeInput) {
   const providerId = ctx.provider.id;
+  const quantity = input.quantity ?? 1;
   const normalizedPlan = ctx.products.planMap.get(input.planId);
   const matchingProduct = input.productInternalId
     ? await getProductByInternalId(ctx.database, input.productInternalId)
@@ -178,6 +182,7 @@ export async function loadSubscribeContext(ctx: PayKitContext, input: SubscribeI
     planFeatures,
     providerCustomerId,
     providerId,
+    quantity,
     scheduledSubscriptions,
     shouldUseCheckout: isPaidTarget && (input.forceCheckout === true || !hasDefaultPaymentMethod),
     storedPlan,
@@ -385,6 +390,10 @@ function isSamePlan(subCtx: SubscribeContext): boolean {
   return subCtx.activeSubscription?.planId === subCtx.storedPlan.id;
 }
 
+function isSameQuantity(subCtx: SubscribeContext): boolean {
+  return (subCtx.activeSubscription?.quantity ?? 1) === subCtx.quantity;
+}
+
 function getSubscriptionEffectiveDate(input: {
   currentPeriodEndAt?: Date | null;
   currentPeriodStartAt?: Date | null;
@@ -436,6 +445,7 @@ async function activateScheduledSubscriptionForGroup(
     subscriptionStatus: string;
     subscriptionCurrentPeriodEndAt?: Date | null;
     subscriptionCurrentPeriodStartAt?: Date | null;
+    subscriptionQuantity?: number | null;
     stripeSubscriptionId?: string | null;
     stripeSubscriptionScheduleId?: string | null;
   },
@@ -484,6 +494,7 @@ async function activateScheduledSubscriptionForGroup(
     subscriptionId: targetSub.id,
     startedAt: targetSub.startedAt ?? activationDate,
     status: input.subscriptionStatus,
+    quantity: input.subscriptionQuantity ?? undefined,
     stripeSubscriptionId: input.stripeSubscriptionId,
     stripeSubscriptionScheduleId: input.stripeSubscriptionScheduleId,
   });
@@ -581,6 +592,7 @@ export async function applySubscriptionWebhookAction(
           stripeSubscriptionId: action.data.subscription.providerSubscriptionId,
           stripeSubscriptionScheduleId:
             action.data.subscription.providerSubscriptionScheduleId ?? null,
+          quantity: action.data.subscription.quantity,
           status: action.data.subscription.status,
         })
       : null);
@@ -597,6 +609,7 @@ export async function applySubscriptionWebhookAction(
   await syncSubscriptionBillingState(ctx.database, {
     stripeSubscriptionId: action.data.subscription.providerSubscriptionId,
     stripeSubscriptionScheduleId: action.data.subscription.providerSubscriptionScheduleId ?? null,
+    quantity: action.data.subscription.quantity,
     subscriptionId: targetSub.id,
   });
 
@@ -702,6 +715,7 @@ export async function applySubscriptionWebhookAction(
           action.data.subscription.providerSubscriptionScheduleId ?? null,
         subscriptionCurrentPeriodEndAt: action.data.subscription.currentPeriodEndAt,
         subscriptionCurrentPeriodStartAt: action.data.subscription.currentPeriodStartAt,
+        subscriptionQuantity: action.data.subscription.quantity,
         subscriptionStatus: action.data.subscription.status,
       });
 
@@ -735,6 +749,64 @@ function getProviderSubscriptionRef(subscription: ActiveSubscription): {
   };
 }
 
+/** Updates the quantity of the current subscription without changing its plan. */
+async function handleQuantityChange(
+  ctx: PayKitContext,
+  subCtx: SubscribeContext,
+): Promise<SubscribeResult> {
+  const activeSubscription = subCtx.activeSubscription;
+  if (!activeSubscription) {
+    throw PayKitError.from("INTERNAL_SERVER_ERROR", PAYKIT_ERROR_CODES.SUBSCRIPTION_CREATE_FAILED);
+  }
+
+  if (!hasProviderSubscription(activeSubscription) || !subCtx.storedPlan.providerProduct) {
+    await syncSubscriptionBillingState(ctx.database, {
+      subscriptionId: activeSubscription.id,
+      quantity: subCtx.quantity,
+    });
+    return buildSubscribeResult({ paymentUrl: null });
+  }
+
+  const activeSubscriptionRef = getProviderSubscriptionRef(activeSubscription);
+  if (!activeSubscriptionRef.subscriptionId) {
+    throw PayKitError.from("INTERNAL_SERVER_ERROR", PAYKIT_ERROR_CODES.SUBSCRIPTION_CREATE_FAILED);
+  }
+
+  const providerResult = await ctx.provider.updateSubscription({
+    providerProduct: subCtx.storedPlan.providerProduct,
+    providerSubscriptionId: activeSubscriptionRef.subscriptionId,
+    quantity: subCtx.quantity,
+  });
+
+  if (!providerResult.subscription) {
+    throw PayKitError.from("INTERNAL_SERVER_ERROR", PAYKIT_ERROR_CODES.SUBSCRIPTION_CREATE_FAILED);
+  }
+
+  await ctx.database.transaction(async (tx) => {
+    await deleteScheduledSubscriptionsInGroupIfNeeded(tx, subCtx);
+    await syncSubscriptionFromProvider(tx, {
+      providerSubscription: providerResult.subscription!,
+      subscriptionId: activeSubscription.id,
+    });
+    await syncSubscriptionBillingState(tx, {
+      currentPeriodEndAt: providerResult.subscription!.currentPeriodEndAt,
+      currentPeriodStartAt: providerResult.subscription!.currentPeriodStartAt,
+      quantity: providerResult.subscription!.quantity ?? subCtx.quantity,
+      stripeSubscriptionId: providerResult.subscription!.providerSubscriptionId,
+      stripeSubscriptionScheduleId:
+        providerResult.subscription!.providerSubscriptionScheduleId ?? null,
+      status: providerResult.subscription!.status,
+      subscriptionId: activeSubscription.id,
+    });
+  });
+
+  return buildSubscribeResult({
+    invoice: providerResult.invoice,
+    paymentUrl: providerResult.paymentUrl,
+    requiredAction: providerResult.requiredAction,
+  });
+}
+
 /** Returns a noop or resumes the current provider subscription. */
 async function handleSamePlanSubscribe(
   ctx: PayKitContext,
@@ -764,6 +836,7 @@ async function handleSamePlanSubscribe(
         cancelAtPeriodEnd: false,
         providerSubscriptionId: activeSubscriptionRef.subscriptionId!,
         providerSubscriptionScheduleId: null,
+        quantity: activeSubscription.quantity,
         status: activeSubscription.status,
       },
     });
@@ -778,6 +851,7 @@ async function handleSamePlanSubscribe(
         stripeSubscriptionId: providerResult.subscription.providerSubscriptionId,
         stripeSubscriptionScheduleId:
           providerResult.subscription.providerSubscriptionScheduleId ?? null,
+        quantity: providerResult.subscription.quantity,
         status: providerResult.subscription.status,
         subscriptionId: activeSubscription.id,
       });
@@ -814,6 +888,7 @@ async function handleInitialSubscribe(
   const providerResult = await ctx.provider.createSubscription({
     providerCustomerId: subCtx.providerCustomerId,
     providerProduct: subCtx.storedPlan.providerProduct!,
+    quantity: subCtx.quantity,
   });
 
   await ctx.database.transaction(async (tx) => {
@@ -871,6 +946,7 @@ async function handleLocalPlanSwitch(
   const providerResult = await ctx.provider.createSubscription({
     providerCustomerId: subCtx.providerCustomerId,
     providerProduct: subCtx.storedPlan.providerProduct!,
+    quantity: subCtx.quantity,
   });
 
   await ctx.database.transaction(async (tx) => {
@@ -938,6 +1014,7 @@ async function handleCancelToFree(
         stripeSubscriptionId: providerResult.subscription.providerSubscriptionId,
         stripeSubscriptionScheduleId:
           providerResult.subscription.providerSubscriptionScheduleId ?? null,
+        quantity: providerResult.subscription.quantity,
         status: providerResult.subscription.status,
         subscriptionId: activeSubscription.id,
       });
@@ -966,6 +1043,7 @@ async function handleScheduledDowngrade(
     providerProduct: subCtx.storedPlan.providerProduct!,
     providerSubscriptionId: activeSubscriptionRef.subscriptionId,
     providerSubscriptionScheduleId: activeSubscriptionRef.subscriptionScheduleId,
+    quantity: subCtx.quantity,
   });
 
   await ctx.database.transaction(async (tx) => {
@@ -990,6 +1068,7 @@ async function handleScheduledDowngrade(
         stripeSubscriptionId: providerResult.subscription.providerSubscriptionId,
         stripeSubscriptionScheduleId:
           providerResult.subscription.providerSubscriptionScheduleId ?? null,
+        quantity: providerResult.subscription.quantity,
         status: providerResult.subscription.status,
         subscriptionId: activeSubscription.id,
       });
@@ -1017,6 +1096,7 @@ async function handleUpgrade(
   const providerResult = await ctx.provider.updateSubscription({
     providerProduct: subCtx.storedPlan.providerProduct!,
     providerSubscriptionId: activeSubscriptionRef.subscriptionId,
+    quantity: subCtx.quantity,
   });
 
   await ctx.database.transaction(async (tx) => {
@@ -1061,6 +1141,7 @@ async function createCheckoutSubscribe(
     },
     providerCustomerId: subCtx.providerCustomerId,
     providerProduct: subCtx.storedPlan.providerProduct!,
+    quantity: subCtx.quantity,
     successUrl: subCtx.successUrl,
   });
 
@@ -1079,6 +1160,7 @@ async function insertLocalTargetSubscription(
     customerId: subCtx.customerId,
     planFeatures: subCtx.planFeatures,
     productInternalId: subCtx.storedPlan.internalId,
+    quantity: subCtx.quantity,
     startedAt: input.startedAt,
     status: input.status,
   });
@@ -1106,6 +1188,7 @@ async function upsertProviderBackedTargetSubscription(
         currentPeriodStartAt: input.subscription.currentPeriodStartAt ?? null,
         stripeSubscriptionId: input.subscription.providerSubscriptionId,
         stripeSubscriptionScheduleId: input.subscription.providerSubscriptionScheduleId ?? null,
+        quantity: input.subscription.quantity ?? subCtx.quantity,
         status: input.subscription.status,
         subscriptionId: existingSub.id,
       });
@@ -1119,6 +1202,7 @@ async function upsertProviderBackedTargetSubscription(
       customerId: subCtx.customerId,
       planFeatures: subCtx.planFeatures,
       productInternalId: subCtx.storedPlan.internalId,
+      quantity: input.subscription.quantity ?? subCtx.quantity,
       startedAt: input.subscription.currentPeriodStartAt ?? new Date(),
       stripeSubscriptionId: input.subscription.providerSubscriptionId,
       stripeSubscriptionScheduleId: input.subscription.providerSubscriptionScheduleId ?? null,
@@ -1349,6 +1433,7 @@ export async function insertSubscriptionRecord(
     currentPeriodStartAt?: Date | null;
     planFeatures: readonly NormalizedPlanFeature[];
     productInternalId: string;
+    quantity?: number;
     scheduledProductId?: string | null;
     startedAt?: Date | null;
     stripeSubscriptionId?: string | null;
@@ -1370,7 +1455,7 @@ export async function insertSubscriptionRecord(
       endedAt: null,
       id: generateId("sub"),
       productInternalId: input.productInternalId,
-      quantity: 1,
+      quantity: input.quantity ?? 1,
       scheduledProductId: input.scheduledProductId ?? null,
       startedAt: input.startedAt ?? now,
       stripeSubscriptionId: input.stripeSubscriptionId ?? null,
@@ -1517,6 +1602,7 @@ export async function activateScheduledSubscription(
     subscriptionId: string;
     startedAt?: Date | null;
     status: string;
+    quantity?: number;
     stripeSubscriptionId?: string | null;
     stripeSubscriptionScheduleId?: string | null;
   },
@@ -1529,6 +1615,7 @@ export async function activateScheduledSubscription(
       currentPeriodEndAt: input.currentPeriodEndAt ?? null,
       currentPeriodStartAt: input.currentPeriodStartAt ?? null,
       endedAt: null,
+      ...(input.quantity !== undefined ? { quantity: input.quantity } : {}),
       startedAt: input.startedAt ?? new Date(),
       stripeSubscriptionId: input.stripeSubscriptionId ?? null,
       stripeSubscriptionScheduleId: input.stripeSubscriptionScheduleId ?? null,
@@ -1589,6 +1676,9 @@ export async function syncSubscriptionFromProvider(
       currentPeriodEndAt: input.providerSubscription.currentPeriodEndAt ?? null,
       currentPeriodStartAt: input.providerSubscription.currentPeriodStartAt ?? null,
       endedAt,
+      ...(input.providerSubscription.quantity !== undefined
+        ? { quantity: input.providerSubscription.quantity }
+        : {}),
       status: input.providerSubscription.status,
       updatedAt: new Date(),
     })
@@ -1604,6 +1694,7 @@ export async function syncSubscriptionBillingState(
     startedAt?: Date | null;
     stripeSubscriptionId?: string | null;
     stripeSubscriptionScheduleId?: string | null;
+    quantity?: number | null;
     status?: string;
   },
 ): Promise<void> {
@@ -1634,6 +1725,7 @@ export async function syncSubscriptionBillingState(
         input.stripeSubscriptionScheduleId !== undefined
           ? input.stripeSubscriptionScheduleId
           : existing.stripeSubscriptionScheduleId,
+      quantity: input.quantity != null ? input.quantity : existing.quantity,
       status: input.status ?? existing.status,
       updatedAt: new Date(),
     })

--- a/packages/paykit/src/subscription/subscription.types.ts
+++ b/packages/paykit/src/subscription/subscription.types.ts
@@ -6,6 +6,7 @@ import type { StoredSubscription } from "../types/models";
 export const subscribeBodySchema = z.object({
   planId: z.string(),
   forceCheckout: z.boolean().optional(),
+  quantity: z.number().int().positive().optional(),
   successUrl: returnUrl(),
   cancelUrl: returnUrl().optional(),
 });

--- a/packages/paykit/src/types/events.ts
+++ b/packages/paykit/src/types/events.ts
@@ -27,6 +27,7 @@ export interface NormalizedSubscription {
   providerProduct?: Record<string, string> | null;
   providerSubscriptionId: string;
   providerSubscriptionScheduleId?: string | null;
+  quantity?: number;
   status: string;
 }
 


### PR DESCRIPTION
## Summary
- Add optional subscription quantity support to subscribe input and provider calls
- Pass quantity through Stripe checkout, create, update, and scheduled changes
- Sync subscription item quantity from provider/webhooks into the existing local subscription quantity column

## Out of scope
- Checkout command idempotency keys
- Resuming open Checkout Sessions
- Automatic tax, Tax ID, or billing address collection
- App-specific organization or entitlement logic

## Test Plan
- pnpm test:unit
- pnpm --filter paykitjs typecheck
- pnpm lint
- pnpm --filter paykitjs build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add end-to-end subscription quantity support. Quantity flows from the subscribe API through Stripe Checkout/create/update/scheduled changes, and is stored and synced in the local subscription.

- New Features
  - Subscribe API accepts optional quantity (positive integer), default 1.
  - Stripe provider sends quantity to Checkout line items, direct create, update, and schedules; normalizes quantity on reads.
  - Same-plan quantity changes update the active subscription in place.
  - Webhooks, scheduled activations, and local writes persist and emit quantity.

- Migration
  - Provider interface now requires a quantity param for `createSubscriptionCheckout`, `createSubscription`, `updateSubscription`, and `scheduleSubscriptionChange`. Update custom providers/callers accordingly.
  - If using the public `subscribe` endpoint, no changes are required (quantity defaults to 1).

<sup>Written for commit e7a75e8091a15a8791905076568f476471b054a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getpaykit/paykit/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription flows now support selecting a quantity for plans.
  * Quantity is now carried through checkout, subscription updates, scheduled changes, and webhook-based syncs.
* **Bug Fixes**
  * Existing subscriptions now keep the correct quantity when changing between the same plan.
  * Subscription details and billing state now stay aligned with the selected quantity.
* **Tests**
  * Added coverage for quantity validation and for provider/database sync behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->